### PR TITLE
Update to README and other small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ checksit check -m cltAnom=cloud_area_fraction /gws/nopw/j04/cmip6_prep_vol1/ukcp
 ```
 * Allows mapping of variable name, for the case that the name of a variable is different between the file to be checked and the template
 * Format - `-m <template variable name>=<file variable name>`
-* **Check how to define multiple mappings**
+* Multiple mappings should be comma separated 
 
 
 #### Ignore attributes

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install -e .
 
 ## Usage
 
-checksit is comprised of four key components - [check](#checksit-check), describe, show-specs, summary
+checksit is comprised of four key components - [check](#checksit-check), [describe](#checksit-describe), [show-specs](#checksit-show-specs), and [summary](#checksit-summary)
 
 
 ## checksit check

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ specs
 ```
 checksit check --specs=ceda-base /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20671201-20681130.nc
 ```
-* Checks file against a given specification. For more info, see checksit show-specs
+* Checks file against a given specification. For more info, see [checksit show-specs](#checksit-show-specs)
 
 
 auto-cache

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ checksit check /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_r
 
 ### Main Features
 
-Define template
+#### Define template
 ```
 checksit check --template=template-cache/rls_rcp85_land-cpm_uk_2.2km_01_day_19801201-19811130.cdl /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20671201-20681130.nc
 ```
@@ -41,7 +41,7 @@ checksit check --template=template-cache/rls_rcp85_land-cpm_uk_2.2km_01_day_1980
 * Note: cdl files are a representation of a netCDF file, being the output from `ncdump -h` on the netCDF file
 
 
-Map variable names
+#### Map variable names
 ```
 checksit check -m cltAnom=cloud_area_fraction /gws/nopw/j04/cmip6_prep_vol1/ukcp18/data/land-prob/v20211110/uk/25km/rcp85/sample/b8110/30y/cltAnom/mon/v20211110/cltAnom_rcp85_land-prob_uk_25km_sample_b8110_30y_mon_20091201-20991130.nc
 ```
@@ -50,14 +50,14 @@ checksit check -m cltAnom=cloud_area_fraction /gws/nopw/j04/cmip6_prep_vol1/ukcp
 * **Check how to define multiple mappings**
 
 
-Ignore attributes
+#### Ignore attributes
 ```
 checksit check --ignore-attrs=global_attributes:time_coverage_start,global_attributes:time_coverage_end,global_attributes:tracking_id /neodc/esacci/sea_ice/data/sea_ice_thickness/L3C/envisat/v2.0/SH/2012/ESACCI-SEAICE-L3C-SITHICK-RA2_ENVISAT-SH50KMEASE2-201202-fv2.0.nc
 ```
 * Define attributes to ignore in checking
 
 
-Define additional rules for checking
+#### Define additional rules for checking
 ```
 checksit check --rules=global_attributes:id=rule-func:match-file-name:lowercase:no-extension /neodc/esacci/sea_ice/data/sea_ice_thickness/L3C/envisat/v2.0/SH/2012/ESACCI-SEAICE-L3C-SITHICK-RA2_ENVISAT-SH50KMEASE2-201202-fv2.0.nc
 ```
@@ -77,21 +77,21 @@ checksit check --rules=global_attributes:id=rule-func:match-file-name:lowercase:
 
 ### Additional Options
 
-specs
+#### specs
 ```
 checksit check --specs=ceda-base /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20671201-20681130.nc
 ```
 * Checks file against a given specification. For more info, see [checksit show-specs](#checksit-show-specs)
 
 
-auto-cache
+#### auto-cache
 ```
 checksit check --auto-cache --template=/badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/08/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_08_day_20671201-20681130.nc /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20671201-20681130.nc
 ```
 * Create a cache of the given template to add to add to checksit's template_cache
 
 
-verbose
+#### verbose
 ```
 checksit check --verbose /group_workspaces/jasmin2/ukcp18/incoming-astephen/ukcordex-example/tasmax_rcp85_land-rcm_uk_12km_EC-EARTH_r12i1p1_HIRHAM5_day_19801201-19901130.nc
 ```

--- a/README.md
+++ b/README.md
@@ -11,65 +11,114 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
+
 ## Usage
+
+checksit is comprised of four key components - check, describe, show-specs, summary
+
+
+## checksit check
+
+Check file against a template.
+
+### Basic Usage
 
 ```
 checksit check /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20671201-20681130.nc
-
-checksit check /group_workspaces/jasmin2/ukcp18/UKcordex/UKCP18_UI_test/tas_rcp85_land-rcm_uk_12km_AD_mon_198012-208011.nc
-
-# Verbose
-checksit check --verbose /group_workspaces/jasmin2/ukcp18/UKcordex/UKCP18_UI_test/tas_rcp85_land-rcm_uk_12km_AD_mon_198012-208011.nc
-
-checksit check --verbose /group_workspaces/jasmin2/ukcp18/UKcordex-laura/tasmax_rcp85_land-rcm_uk_12km_EC-EARTH_r12i1p1_HIRHAM5_day_19801201-19901130.nc
 ```
+* Checks format of file.
+* checksit searches its template cache for a similar file to compare against
 
-## Features
 
-### Mapping the names of attributes or sub-dictionaries (such as variables)
+### Main Features
 
-Say you want to compare the contents of a data file with a template file, but you know that
-a variable has been given a different NetCDF variable ID in the data file, you can tell the 
-checker to map the name as follows:
+Define template
+```
+checksit check --template=template-cache/rls_rcp85_land-cpm_uk_2.2km_01_day_19801201-19811130.cdl /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20671201-20681130.nc
+```
+* Use `--template` flag to define a template to use
+* Template can be in template-cache or any file user has access to
+* Note: cdl files are a representation of a netCDF file, being the output from `ncdump -h` on the netCDF file
+
+
+Map variable names
+```
+checksit check -m cltAnom=cloud_area_fraction /gws/nopw/j04/cmip6_prep_vol1/ukcp18/data/land-prob/v20211110/uk/25km/rcp85/sample/b8110/30y/cltAnom/mon/v20211110/cltAnom_rcp85_land-prob_uk_25km_sample_b8110_30y_mon_20091201-20991130.nc
+```
+* Allows mapping of variable name, for the case that the name of a variable is different between the file to be checked and the template
+* Format - `-m <template variable name>=<file variable name>`
+* **Check how to define multiple mappings**
+
+
+Ignore attributes
+```
+checksit check --ignore-attrs=global_attributes:time_coverage_start,global_attributes:time_coverage_end,global_attributes:tracking_id /neodc/esacci/sea_ice/data/sea_ice_thickness/L3C/envisat/v2.0/SH/2012/ESACCI-SEAICE-L3C-SITHICK-RA2_ENVISAT-SH50KMEASE2-201202-fv2.0.nc
+```
+* Define attributes to ignore in checking
+
+
+Define additional rules for checking
+```
+checksit check --rules=global_attributes:id=rule-func:match-file-name:lowercase:no-extension /neodc/esacci/sea_ice/data/sea_ice_thickness/L3C/envisat/v2.0/SH/2012/ESACCI-SEAICE-L3C-SITHICK-RA2_ENVISAT-SH50KMEASE2-201202-fv2.0.nc
+```
+* Check items against defined rules
+* Format - `<what to check>=<rule type>:<function/check>[:<extras>[:<extras>...]]`
+* Four options for `<rule type>`:
+  * `rule-func` - check item against a defined function, 4 options:
+    * `match-file-name` - item must be the same as the file name, allowing for formatting through `<extras>` - `lowercase`, `uppercase`, `no_extension` - example: `global_attributes:id=rule-func:match-file-name:lowercase:no-extension`
+    * `match-one-of` - item must be the same as one of the `<extras>` given
+    * `match-one-or-more-of` - item must be the same as one or more of the `<extras>` given
+    * `string-of-length` - item must be the same length as given `<extra>` or greater if `+` is given at end of `<extra>` - example: `global_attributes:project=rule-func:string-of-length:10,global_attributes:contact=rule-func:string-of-length:100+`
+  * `type-rule` - check item is of type as defined in `<extra>` - example: `transverse_mercator:false_northing=type-rule:integer`
+  * `regex` - check item for regular expression match - example: `global_attributes:project=regex:ukcp18`
+  * `regex-rule` - check item matches pre-defined regex rule, name of which is given in `<extra>`
+    * current options are `integer`,`valid-email`,`valid-url`,`valid-url-or-na`,`match:vN.M`,`datetime`,`datetime-or-na`,`number`
+
+
+### Additional Options
+
+specs
+```
+checksit check --specs=ceda-base /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20671201-20681130.nc
+```
+* Checks file against a given specification. For more info, see checksit show-specs
+
+
+auto-cache
+```
+checksit check --auto-cache --template=/badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/08/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_08_day_20671201-20681130.nc /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20671201-20681130.nc
+```
+* Create a cache of the given template to add to add to checksit's template_cache
+
+
+verbose
+```
+checksit check --verbose /group_workspaces/jasmin2/ukcp18/incoming-astephen/ukcordex-example/tasmax_rcp85_land-rcm_uk_12km_EC-EARTH_r12i1p1_HIRHAM5_day_19801201-19901130.nc
+```
+* Print additional information
+
+
+
+## checksit describe
 
 ```
-$ checksit check  -m cltAnom=cloud_area_fraction  /gws/nopw/j04/cmip6_prep_vol1/ukcp18/data/land-prob/v20211110/uk/25km/rcp85/sample/b8110/30y/cltAnom/mon/v20211110/cltAnom_rcp85_land-prob_uk_25km_sample_b8110_30y_mon_20091201-20991130.nc
+checksit describe
 ```
-
-This will find the "cloud_area_fraction" variable ID in the data file and match it to the 
-"cltAnom" variable dictionary in the template.
-
-### Connecting to controlled vocabularies
-
-```
-$ checksit check  -m cltAnom=cloud_area_fraction  /gws/nopw/j04/cmip6_prep_vol1/ukcp18/data/land-prob/v20211110/uk/25km/rcp85/sample/b8110/30y/cltAnom/mon/v20211110/cltAnom_rcp85_land-prob_uk_25km_sample_b8110_30y_mon_20091201-20991130.nc
-
-Running with:
-        Template: template-cache/cltAnom_rcp85_land-prob_uk_25km_sample_b8110_30y_mon_20091201-20991130.cdl
-        Datafile: /gws/nopw/j04/cmip6_prep_vol1/ukcp18/data/land-prob/v20211110/uk/25km/rcp85/sample/b8110/30y/cltAnom/mon/v20211110/cltAnom_rcp85_land-prob_uk_25km_sample_b8110_30y_mon_20091201-20991130.nc
+* Prints docstring of rules that can be used in `checksit check --rules`
+* Individual rules can be printed out, e.g. `checksit describe match-one-of`
 
 
----------------- Running checks ------------------
 
-[FAILED] with 2 errors:
-
-        01. [variables] sample:units: 'UNDEFINED' does not match expected: '1'
-        02. [global_attributes] 'CF-1.7' not in vocab options: ['CF-1.5', 'CF-1.6']
-```
-
-
-## Ideas
+## checksit show-specs
 
 ```
-template_cache=my-template-cache
-basedir=/badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day
-
-for latest_dir in $(find -L $basedir -type d -name latest); do
-    first_file=$(ls $latest_dir/*.nc | head -1)
-    facets=$(basename $first_file | cut -d_ -f1-7 | sed 's/_/ /g')
-#rss_rcp85_land-cpm_uk_2.2km_01_day_19801201-19811130.nc
-    echo $facets
-    ncdump -h $first_file
-done
-
+checksit show-specs <spec-id>
 ```
+* Prints out specs for a given spec-id, e.g. `ceda-base`
+* sped-ids are saved in checksit/specs/groups
+
+
+
+## checksit summary
+
+* Summarises output from a number of log files created through `checksit check`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install -e .
 
 ## Usage
 
-checksit is comprised of four key components - check, describe, show-specs, summary
+checksit is comprised of four key components - [check](#checksit-check), describe, show-specs, summary
 
 
 ## checksit check

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ checksit check --rules=global_attributes:id=rule-func:match-file-name:lowercase:
 * Four options for `<rule type>`:
   * `rule-func` - check item against a defined function, 4 options:
     * `match-file-name` - item must be the same as the file name, allowing for formatting through `<extras>` - `lowercase`, `uppercase`, `no_extension` - example: `global_attributes:id=rule-func:match-file-name:lowercase:no-extension`
-    * `match-one-of` - item must be the same as one of the `<extras>` given
-    * `match-one-or-more-of` - item must be the same as one or more of the `<extras>` given
+    * `match-one-of` - item must be the same as one of the `<extras>` given. Multiple options should be separated by a `|` and surrounded by double quotation marks - example: `global_attributes:project=rule-func:match-one-of:"ukcp18|ukcp09"`
+    * `match-one-or-more-of` - item must be the same as one or more of the `<extras>` given. Multiple options should be separated by a `|` and surrounded by double quotation marks - example: `global_attributes:contact=rule-func:match-one-or-more-of:"ukcpproject@metoffice.gov.uk|UKCP Team|MOHC"`
     * `string-of-length` - item must be the same length as given `<extra>` or greater if `+` is given at end of `<extra>` - example: `global_attributes:project=rule-func:string-of-length:10,global_attributes:contact=rule-func:string-of-length:100+`
   * `type-rule` - check item is of type as defined in `<extra>` - example: `transverse_mercator:false_northing=type-rule:integer`
   * `regex` - check item for regular expression match - example: `global_attributes:project=regex:ukcp18`

--- a/checksit/generic.py
+++ b/checksit/generic.py
@@ -40,11 +40,11 @@ def check_global_attrs(dct, defined_attrs=None, vocab_attrs=None):
     errors = []
 
     for attr in defined_attrs:
-        if is_undefined(dct.get(attr)):
+        if is_undefined(dct['global_attributes'].get(attr)):
             errors.append(f"[global-attributes:**************:{attr}]: Attribute '{attr}' must have a valid definition.")
 
     for attr in vocab_attrs:
-        errors.extend(vocabs.check(vocab_attrs[attr], dct.get(attr, UNDEFINED), label=f"[global-attributes:******:{attr}]***"))
+        errors.extend(vocabs.check(vocab_attrs[attr], dct['global_attributes'].get(attr, UNDEFINED), label=f"[global-attributes:******:{attr}]***"))
  
 
     return errors

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ click
 pyyaml
 cf-python
 netcdf4
-
+pandas


### PR DESCRIPTION
# Changes

### README.md
Big update to README.md, each of the options in `checksit check` have initial description with example of how to use, as in Issue #14. 
The other three options for `checksit` have a basic description that can be flushed out as that functionality is increased.

### requirements.txt
Addition of `pandas` requirement, as it is used in `checksit summary`, as mentioned in Issue #13.

### checksit/generic.py
Within `check_global_attrs`, actually looks at global attributes within `dct` rather than just the top level, which was global attributes, variables and dimensions (I think). This meant that when checking a global attribute exists or its vocabs, the attribute was not being found due to the code looking in the wrong place.