### PR TITLE
checksit show-specs to print out specs within folders

### DIFF
--- a/checksit/specs.py
+++ b/checksit/specs.py
@@ -26,11 +26,12 @@ def load_specs(spec_ids=None):
 def show_specs(spec_ids=None, verbose=False):
     
     all_specs = load_specs(spec_ids)
-   
+    spec_ids_names = tuple([(spec_id.split("/")[-1]) for spec_id in spec_ids])
+
     if not spec_ids:
         specs = all_specs
     else:
-        specs = [(spec_id, spec) for (spec_id, spec) in all_specs.items() if spec_id in spec_ids]
+        specs = [(spec_ids[spec_ids_names.index(spec_id)], spec) for (spec_id, spec) in all_specs.items() if spec_id in spec_ids_names]
 
     print("Specifications:")
     for spec_id, spec in specs:


### PR DESCRIPTION
Previously, `checksit show-specs ncas-amof-2.0.0/amof-global-attrs ceda-base` would not print out the specs in the `specs/groups/ncas-amof-2.0.0/amof-global-attrs.yml`, but would print out those in `specs/groups/ceda-base.yml`.

The show_specs function in specs.py now matches spec_id between the key in the spec file and a list of spec_ids that removes the spec group folder (e.g. `ncas-amof-2.0.0/amof-global-attrs` becomes `amof-global-attrs`), but still prints out `ncas-amof-2.0.0/amof-global-attrs`.