### PR TITLE
Qc flag checks

### DIFF
--- a/checksit/make_specs.py
+++ b/checksit/make_specs.py
@@ -14,18 +14,18 @@ def map_data_type(dtype):
         'byte':'byte',
     }
     return data_map[dtype]
-    
-    
+
+
 
 # main function
 
-def make_amof_specs(version_number): 
+def make_amof_specs(version_number):
     ###############
     # DIRECTORIES #
     ###############
-    
-    cvs_dir = f"./checksit/vocabs/AMF_CVs/{version_number}"
-    out_dir = f"./specs/groups/ncas-amof-{version_number}"
+
+    cvs_dir = f"vocabs/AMF_CVs/{version_number}"
+    out_dir = f"../specs/groups/ncas-amof-{version_number}"
 
 
     ################
@@ -103,7 +103,7 @@ def make_amof_specs(version_number):
         f.write('    rules_attrs:\n')
         for attr, rule in attr_rules.items():
             if rule.split(':')[0] in ['regex','regex-rule','type-rule','rule-func']:
-                f.write(f'      {attr}: {rule}\n') 
+                f.write(f'      {attr}: {rule}\n')
 
     ####################
     # DEPLOYMENT MODES #
@@ -125,7 +125,7 @@ def make_amof_specs(version_number):
                     if attr == 'type':
                         attr_value = map_data_type(attr_value)
                     deploy_vars[variable].append(f'{attr}:{attr_value}')
-         
+
 
 
         spec_file_name = f'{out_dir}/amof-common-{mode}.yml'
@@ -145,7 +145,7 @@ def make_amof_specs(version_number):
                      '  params:\n    dimensions:\n'))
             for dim in deploy_dims:
                 f.write(f'      - {dim}\n')
-    
+
     ##############
     ## PRODUCTS ##
     ##############
@@ -183,11 +183,11 @@ def make_amof_specs(version_number):
         else:
             prod_dims_exist = False
 
-    
+
         if exists(f'{cvs_dir}/AMF_product_{product}_global-attributes.json'):
             with open(f'{cvs_dir}/AMF_product_{product}_global-attributes.json') as f:
                 data = json.load(f)[f'product_{product}_global-attributes']
-            
+
                 attr_rules = {}
 
                 for attr in data.keys():
@@ -240,12 +240,13 @@ def make_amof_specs(version_number):
         else:
             prod_attrs_exist = False
 
-        
+
 
         spec_file_name = f'{out_dir}/amof-{product}.yml'
         with open(spec_file_name, 'w') as f:
             if prod_vars_exist:
                 for i, var in enumerate(product_info.items()):
+                    qc_flags = False
                     f.write(f'var-requires{i}:\n')
                     f.write(('  func: checksit.generic.check_var\n'
                              '  params:\n    variable:\n'
@@ -253,8 +254,13 @@ def make_amof_specs(version_number):
                     for attr in var[1]:
                         attr_key = attr.split(':')[0]
                         attr_value = ':'.join(attr.split(':')[1:])
-                        f.write(f'      - {attr_key}:{attr_value}\n')
-    
+                        if attr_key not in ["flag_values", "flag_meanings"]:
+                            f.write(f'      - {attr_key}:{attr_value}\n')
+                        else:
+                            qc_flags = True
+                    if qc_flags:
+                        f.write(f'    attr_rules:\n      - rule-func:check-qc-flags\n')
+
             if prod_dims_exist:
                 f.write(('dims-requires:\n  func: checksit.generic.check_dim_exists\n'
                          '  params:\n    dimensions:\n'))
@@ -270,10 +276,10 @@ def make_amof_specs(version_number):
                 f.write('    rules_attrs:\n')
                 for attr, rule in attr_rules.items():
                     if rule.split(':')[0] in ['regex','regex-rule','type-rule','rule-func']:
-                        f.write(f'      {attr}: {rule}\n') 
+                        f.write(f'      {attr}: {rule}\n')
 
 
 if __name__ == "__main__":
     import sys
     version_number = sys.argv[1]
-    make_amof_specs(version_number) 
+    make_amof_specs(version_number)

--- a/specs/groups/ncas-amof-2.0.0/amof-acoustic-backscatter-winds.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-acoustic-backscatter-winds.yml
@@ -165,8 +165,8 @@ var-requires10:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: Mean Winds
-      - flag_values:0b, 1b, 2b, 3b, 4b, 5b, 6b
-      - flag_meanings:not_used good_data suspect_data_wind_speed_value_outside_operational_range_(0_to_20_m_s-1) suspect_data_wind_speed_==_0 bad_data_signal_consensus_poor bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -177,8 +177,8 @@ var-requires11:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: Eastward Wind Component (U)
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b
-      - flag_meanings:not_used good_data suspect_data_value_outside_operational_range_(-20_m_s-1_to_20_m_s-1) bad_data_signal_consensus_poor bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -189,8 +189,8 @@ var-requires12:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: Northward Wind Component (V)
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b
-      - flag_meanings:not_used good_data suspect_data_value_outside_operational_range_(-20_m_s-1_to_20_m_s-1) bad_data_signal_consensus_poor bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -201,8 +201,8 @@ var-requires13:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: Upward Air Velocity (W)
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b
-      - flag_meanings:not_used good_data suspect_data_value_outside_operational_range_(-20_m_s-1_to_20_m_s-1) bad_data_signal_consensus_poor bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -213,8 +213,8 @@ var-requires14:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: Backscatter
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range bad_data_signal_consensus_poor bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -225,8 +225,8 @@ var-requires15:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: Background Noise
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data suspect_data_background_noise_>_2_dB bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-aerosol-backscatter-radial-winds.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-aerosol-backscatter-radial-winds.yml
@@ -123,8 +123,8 @@ var-requires8:
       - type:byte
       - units:1
       - long_name:Data Quality flag: Radial Velocity of Scatterers Away From Instrument
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b, 8b, 9b
-      - flag_meanings:not_used good_data bad_data_data_values_outside_measurement_range bad_data_signal_below_instrument_threshold suspect_data_line_of_sight_radial_velocity_ -19m_s-1_<> _19m_s-1 suspect_data_line_of_sight_radial_velocity_wind_shear_-5m_s-1_<>_5m_s-1 suspect_data_instrument_internal_temperature_outside_operational_range_low _(15C) suspect_data_Instrument_internal_temperature_outside_operational_range_high_(40C) bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -134,8 +134,8 @@ var-requires9:
       - type:byte
       - units:1
       - long_name:Data Quality flag: Backscatter
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b, 8b, 9b
-      - flag_meanings:not_used good_data bad_data_data_values_outside_measurement_range bad_data_signal_below_instrument_threshold suspect_data_line_of_sight_radial_velocity_ -19m_s-1_<> _19m_s-1 suspect_data_line_of_sight_radial_velocity_wind_shear_-5m_s-1_<>_5m_s-1 suspect_data_instrument_internal_temperature_outside_operational_range_low _(15C) suspect_data_Instrument_internal_temperature_outside_operational_range_high_(40C) bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-aerosol-backscatter.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-aerosol-backscatter.yml
@@ -206,8 +206,8 @@ var-requires13:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_attenuated_aerosol_backscatter_coefficient_outside_instrument_operational_range bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-aerosol-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-aerosol-concentration.yml
@@ -23,5 +23,5 @@ var-requires1:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_bad_data_to_be_defined suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-aerosol-extinction.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-aerosol-extinction.yml
@@ -52,8 +52,8 @@ var-requires3:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: 355nm
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b
-      - flag_meanings:not_used good_data good_data_only_355nm_channel_operating suspect_data_cloudy_profile bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -64,8 +64,8 @@ var-requires4:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: 316nm
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b
-      - flag_meanings:not_used good_data good_data_only_316nm_channel_operating suspect_data_cloudy_profile bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-aerosol-no3-so4-nh3-org-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-aerosol-no3-so4-nh3-org-concentration.yml
@@ -68,8 +68,8 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: NO3
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_bad_data_to_be_defined suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -80,8 +80,8 @@ var-requires5:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: SO4
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_bad_data_to_be_defined suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -92,8 +92,8 @@ var-requires6:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: NH3
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_bad_data_to_be_defined suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -104,5 +104,5 @@ var-requires7:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Organics
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_bad_data_to_be_defined suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-aerosol-optical-depth.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-aerosol-optical-depth.yml
@@ -52,8 +52,8 @@ var-requires3:
       - dimension:time, index
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_suspect_data_to_be_defined suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-aerosol-size-distribution.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-aerosol-size-distribution.yml
@@ -159,8 +159,8 @@ var-requires11:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_bad_data_to_be_defined suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-boundary-layer-temperature-profiles.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-boundary-layer-temperature-profiles.yml
@@ -40,8 +40,8 @@ var-requires2:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Temperature
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_temperature_outside_sensor_operational_range bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires3:
   func: checksit.generic.check_var
   params:
@@ -52,8 +52,8 @@ var-requires3:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_relative_humidity_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -64,8 +64,8 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Pressure
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_pressure_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -76,8 +76,8 @@ var-requires5:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Precipitation
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_precipitation_detected suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -88,8 +88,8 @@ var-requires6:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -100,8 +100,8 @@ var-requires7:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -112,8 +112,8 @@ var-requires8:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -124,8 +124,8 @@ var-requires9:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -136,8 +136,8 @@ var-requires10:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -148,8 +148,8 @@ var-requires11:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -160,8 +160,8 @@ var-requires12:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -172,8 +172,8 @@ var-requires13:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -184,8 +184,8 @@ var-requires14:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -196,8 +196,8 @@ var-requires15:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -208,8 +208,8 @@ var-requires16:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -220,8 +220,8 @@ var-requires17:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -232,8 +232,8 @@ var-requires18:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -244,8 +244,8 @@ var-requires19:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -256,8 +256,8 @@ var-requires20:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b
-      - flag_meanings:not_used good_data_temperature_stability_in_the_range_0_to_5mK suspect_data_temperature_stability_in_the_range_5_to_10mK suspect_data_temperature_stability_in_the_range_10_to_50mK suspect_data_temperature_stability_in_the_range_50_to_100mK suspect_data_temperature_stability_in_the_range_100_to_500mK bad_data_temperature_stability_>500mK suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -268,8 +268,8 @@ var-requires21:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b
-      - flag_meanings:not_used good_data_temperature_stability_in_the_range_0_to_5mK suspect_data_temperature_stability_in_the_range_5_to_10mK suspect_data_temperature_stability_in_the_range_10_to_50mK suspect_data_temperature_stability_in_the_range_50_to_100mK suspect_data_temperature_stability_in_the_range_100_to_500mK bad_data_temperature_stability_>500mK suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-brightness-temperature.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-brightness-temperature.yml
@@ -54,8 +54,8 @@ var-requires3:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Temperature
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_temperature_outside_sensor_operational_range bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -66,8 +66,8 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_relative_humidity_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -78,8 +78,8 @@ var-requires5:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Pressure
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_pressure_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -90,8 +90,8 @@ var-requires6:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Precipitation
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_precipitation_detected suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -102,8 +102,8 @@ var-requires7:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -114,8 +114,8 @@ var-requires8:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -126,8 +126,8 @@ var-requires9:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -138,8 +138,8 @@ var-requires10:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -150,8 +150,8 @@ var-requires11:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -162,8 +162,8 @@ var-requires12:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -174,8 +174,8 @@ var-requires13:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -186,8 +186,8 @@ var-requires14:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -198,8 +198,8 @@ var-requires15:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -210,8 +210,8 @@ var-requires16:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -222,8 +222,8 @@ var-requires17:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -234,8 +234,8 @@ var-requires18:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -246,8 +246,8 @@ var-requires19:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -258,8 +258,8 @@ var-requires20:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -270,8 +270,8 @@ var-requires21:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b
-      - flag_meanings:not_used good_data_temperature_stability_in_the_range_0_to_5mK suspect_data_temperature_stability_in_the_range_5_to_10mK suspect_data_temperature_stability_in_the_range_10_to_50mK suspect_data_temperature_stability_in_the_range_50_to_100mK suspect_data_temperature_stability_in_the_range_100_to_500mK bad_data_temperature_stability_>500mK suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires22:
   func: checksit.generic.check_var
   params:
@@ -282,8 +282,8 @@ var-requires22:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b
-      - flag_meanings:not_used good_data_temperature_stability_in_the_range_0_to_5mK suspect_data_temperature_stability_in_the_range_5_to_10mK suspect_data_temperature_stability_in_the_range_10_to_50mK suspect_data_temperature_stability_in_the_range_50_to_100mK suspect_data_temperature_stability_in_the_range_100_to_500mK bad_data_temperature_stability_>500mK suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-ch4-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-ch4-concentration.yml
@@ -70,5 +70,5 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_data_not_quality_controlled bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-cloud-base.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-cloud-base.yml
@@ -176,8 +176,8 @@ var-requires11:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Cloud Base
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b
-      - flag_meanings:not_used good_data suspect_data_no_signifcant_backscatter suspect_data_full_obscuration_determined_but_no_cloud_base_detected suspect_data_some_obscuration_detected_but_determined_to_be_transparent bad_data_raw_data_missing suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-cloud-coverage.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-cloud-coverage.yml
@@ -191,8 +191,8 @@ var-requires12:
       - dimension:time. layer_index
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b
-      - flag_meanings:not_used good_data suspect_data_no_signifcant_backscatter suspect_data_full_obscuration_determined_but_no_cloud_base_detected suspect_data_some_obscuration_detected_but_determined_to_be_transparent bad_data_raw_data_missing suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-co-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-co-concentration.yml
@@ -70,5 +70,5 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_data_not_quality_controlled bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-co-h2-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-co-h2-concentration.yml
@@ -132,8 +132,8 @@ var-requires8:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: CO
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_data_not_quality_controlled bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -144,5 +144,5 @@ var-requires9:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: H2
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_data_not_quality_controlled bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-co2-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-co2-concentration.yml
@@ -70,5 +70,5 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_data_not_quality_controlled bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-depolarisation-ratio.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-depolarisation-ratio.yml
@@ -153,8 +153,8 @@ var-requires10:
       - dimension:time, index_of_range, index_of_angle
       - units:1
       - long_name:Data Quality flag:  Attenuated backscatter coefficient (Planar Polarised)
-      - flag_values:0b,1b, 2b, 3b,4b, 5b, 6b, 7b, 8b, 9b,10b
-      - flag_meanings:not_used good_data snr_less_than_3 snr_less_than_2 snr_less_than_1 doppler_velocity_less_out_of_+-19ms-1_range user_changed_number_of_gates_during_the_day_so padding_with_fill_value wind_profiles_are_clipped_by_manufacturer_software_so padding_wih_fill_value padded_crosspolarised_or_copolarised_data_to_match_the_other_in_dimension_size bad_data_gate_index_exceeds_number_of_measurement_gates_in_use crosspolarised_and_copolarised_data_do_not_have_matching_ranges_or_directions
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -165,8 +165,8 @@ var-requires11:
       - dimension:time, index_of_range, index_of_angle
       - units:1
       - long_name:Data Quality flag:  Attenuated backscatter coefficient (Cross Polarised)
-      - flag_values:0b,1b, 2b, 3b,4b, 5b, 6b, 7b, 8b, 9b,10b
-      - flag_meanings:not_used good_data snr_less_than_3 snr_less_than_2 snr_less_than_1 doppler_velocity_less_out_of_+-19ms-1_range user_changed_number_of_gates_during_the_day_so padding_with_fill_value wind_profiles_are_clipped_by_manufacturer_software_so padding_wih_fill_value padded_crosspolarised_or_copolarised_data_to_match_the_other_in_dimension_size bad_data_gate_index_exceeds_number_of_measurement_gates_in_use crosspolarised_and_copolarised_data_do_not_have_matching_ranges_or_directions
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -177,8 +177,8 @@ var-requires12:
       - dimension:time, index_of_range, index_of_angle
       - units:1
       - long_name:Data Quality flag:  Depolarisation R
-      - flag_values:0b,1b, 2b, 3b,4b, 5b, 6b, 7b, 8b, 9b,10b
-      - flag_meanings:not_used good_data snr_less_than_3 snr_less_than_2 snr_less_than_1 doppler_velocity_less_out_of_+-19ms-1_range user_changed_number_of_gates_during_the_day_so padding_with_fill_value wind_profiles_are_clipped_by_manufacturer_software_so padding_wih_fill_value padded_crosspolarised_or_copolarised_data_to_match_the_other_in_dimension_size bad_data_gate_index_exceeds_number_of_measurement_gates_in_use crosspolarised_and_copolarised_data_do_not_have_matching_ranges_or_directions
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-dew-point.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-dew-point.yml
@@ -99,5 +99,5 @@ var-requires6:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_contact_creator bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-flux-components.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-flux-components.yml
@@ -1125,8 +1125,8 @@ var-requires74:
       - dimension:time
       - units:1
       - long_name:Quality flag: Skew U
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires75:
   func: checksit.generic.check_var
   params:
@@ -1137,8 +1137,8 @@ var-requires75:
       - dimension:time
       - units:1
       - long_name:Quality flag: Skew V
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires76:
   func: checksit.generic.check_var
   params:
@@ -1149,8 +1149,8 @@ var-requires76:
       - dimension:time
       - units:1
       - long_name:Quality flag: Skew W
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires77:
   func: checksit.generic.check_var
   params:
@@ -1161,8 +1161,8 @@ var-requires77:
       - dimension:time
       - units:1
       - long_name:Quality flag: Skew Ts
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires78:
   func: checksit.generic.check_var
   params:
@@ -1173,8 +1173,8 @@ var-requires78:
       - dimension:time
       - units:1
       - long_name:Quality flag: Kurtosis U
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires79:
   func: checksit.generic.check_var
   params:
@@ -1185,8 +1185,8 @@ var-requires79:
       - dimension:time
       - units:1
       - long_name:Quality flag: Kurtosis V
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires80:
   func: checksit.generic.check_var
   params:
@@ -1197,8 +1197,8 @@ var-requires80:
       - dimension:time
       - units:1
       - long_name:Quality flag: Kurtosis W
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires81:
   func: checksit.generic.check_var
   params:
@@ -1209,8 +1209,8 @@ var-requires81:
       - dimension:time
       - units:1
       - long_name:Quality flag: Kurtosis Ts
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires82:
   func: checksit.generic.check_var
   params:
@@ -1221,8 +1221,8 @@ var-requires82:
       - dimension:time
       - units:1
       - long_name:Quality flag: Steady State Class WU
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b, 8b, 9b
-      - flag_meanings:not_used good_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data bad_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires83:
   func: checksit.generic.check_var
   params:
@@ -1233,8 +1233,8 @@ var-requires83:
       - dimension:time
       - units:1
       - long_name:Quality flag: Steady State Class WV
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b, 8b, 9b
-      - flag_meanings:not_used good_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data bad_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires84:
   func: checksit.generic.check_var
   params:
@@ -1245,8 +1245,8 @@ var-requires84:
       - dimension:time
       - units:1
       - long_name:Quality flag: Steady State Class WTs
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b, 8b, 9b
-      - flag_meanings:not_used good_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data bad_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires85:
   func: checksit.generic.check_var
   params:
@@ -1257,8 +1257,8 @@ var-requires85:
       - dimension:time
       - units:1
       - long_name:Quality flag: WU
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:bad_data good_data _good_for_reasearch suspect_data_good_for_general_use suspect_data_requires_further_checking_but_may_be_ok_for_general_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires86:
   func: checksit.generic.check_var
   params:
@@ -1268,6 +1268,8 @@ var-requires86:
       - type:byte
       - dimension:time
       - units:1
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-flux-estimates.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-flux-estimates.yml
@@ -172,8 +172,8 @@ var-requires11:
       - dimension:time
       - units:1
       - long_name:Quality flag: Skew U
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -184,8 +184,8 @@ var-requires12:
       - dimension:time
       - units:1
       - long_name:Quality flag: Skew V
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -196,8 +196,8 @@ var-requires13:
       - dimension:time
       - units:1
       - long_name:Quality flag: Skew W
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -208,8 +208,8 @@ var-requires14:
       - dimension:time
       - units:1
       - long_name:Quality flag: Skew Ts
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -220,8 +220,8 @@ var-requires15:
       - dimension:time
       - units:1
       - long_name:Quality flag: Kurtosis U
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -232,8 +232,8 @@ var-requires16:
       - dimension:time
       - units:1
       - long_name:Quality flag: Kurtosis V
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -244,8 +244,8 @@ var-requires17:
       - dimension:time
       - units:1
       - long_name:Quality flag: Kurtosis W
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -256,8 +256,8 @@ var-requires18:
       - dimension:time
       - units:1
       - long_name:Quality flag: Kurtosis Ts
-      - flag_values:0b,1b, 2b
-      - flag_meanings:bad_data good_data suspect_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -268,8 +268,8 @@ var-requires19:
       - dimension:time
       - units:1
       - long_name:Quality flag: Steady State Class WU
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b, 8b, 9b
-      - flag_meanings:not_used good_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data bad_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -280,8 +280,8 @@ var-requires20:
       - dimension:time
       - units:1
       - long_name:Quality flag: Steady State Class WV
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b, 8b, 9b
-      - flag_meanings:not_used good_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data bad_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -292,8 +292,8 @@ var-requires21:
       - dimension:time
       - units:1
       - long_name:Quality flag: Steady State Class WTs
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b, 8b, 9b
-      - flag_meanings:not_used good_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data suspect_data bad_data
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires22:
   func: checksit.generic.check_var
   params:
@@ -304,8 +304,8 @@ var-requires22:
       - dimension:time
       - units:1
       - long_name:Quality flag: WU
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:bad_data good_data _good_for_reasearch suspect_data_good_for_general_use suspect_data_requires_further_checking_but_may_be_ok_for_general_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires23:
   func: checksit.generic.check_var
   params:
@@ -316,8 +316,8 @@ var-requires23:
       - dimension:time
       - units:1
       - long_name:Quality flag: WV
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:bad_data good_data _good_for_reasearch suspect_data_good_for_general_use suspect_data_requires_further_checking_but_may_be_ok_for_general_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires24:
   func: checksit.generic.check_var
   params:
@@ -328,8 +328,8 @@ var-requires24:
       - dimension:time
       - units:1
       - long_name:Quality flag: WTs
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:bad_data good_data _good_for_reasearch suspect_data_good_for_general_use suspect_data_requires_further_checking_but_may_be_ok_for_general_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires25:
   func: checksit.generic.check_var
   params:
@@ -340,5 +340,5 @@ var-requires25:
       - dimension:time
       - units:1
       - long_name:Quality flag: General Turbulent Characteristic of W Class
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:bad_data good_data _good_for_reasearch suspect_data_good_for_general_use suspect_data_requires_further_checking_but_may_be_ok_for_general_use
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-full-troposphere-temperature-profiles.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-full-troposphere-temperature-profiles.yml
@@ -40,8 +40,8 @@ var-requires2:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Temperature
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_temperature_outside_sensor_operational_range bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires3:
   func: checksit.generic.check_var
   params:
@@ -52,8 +52,8 @@ var-requires3:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_relative_humidity_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -64,8 +64,8 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Pressure
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_pressure_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -76,8 +76,8 @@ var-requires5:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Precipitation
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_precipitation_detected suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -88,8 +88,8 @@ var-requires6:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -100,8 +100,8 @@ var-requires7:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -112,8 +112,8 @@ var-requires8:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -124,8 +124,8 @@ var-requires9:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -136,8 +136,8 @@ var-requires10:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -148,8 +148,8 @@ var-requires11:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -160,8 +160,8 @@ var-requires12:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -172,8 +172,8 @@ var-requires13:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -184,8 +184,8 @@ var-requires14:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -196,8 +196,8 @@ var-requires15:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -208,8 +208,8 @@ var-requires16:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -220,8 +220,8 @@ var-requires17:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -232,8 +232,8 @@ var-requires18:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -244,8 +244,8 @@ var-requires19:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -256,8 +256,8 @@ var-requires20:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b
-      - flag_meanings:not_used good_data_temperature_stability_in_the_range_0_to_5mK suspect_data_temperature_stability_in_the_range_5_to_10mK suspect_data_temperature_stability_in_the_range_10_to_50mK suspect_data_temperature_stability_in_the_range_50_to_100mK suspect_data_temperature_stability_in_the_range_100_to_500mK bad_data_temperature_stability_>500mK suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -268,8 +268,8 @@ var-requires21:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b
-      - flag_meanings:not_used good_data_temperature_stability_in_the_range_0_to_5mK suspect_data_temperature_stability_in_the_range_5_to_10mK suspect_data_temperature_stability_in_the_range_10_to_50mK suspect_data_temperature_stability_in_the_range_50_to_100mK suspect_data_temperature_stability_in_the_range_100_to_500mK bad_data_temperature_stability_>500mK suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-h2-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-h2-concentration.yml
@@ -70,5 +70,5 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_data_not_quality_controlled bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-halocarbon-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-halocarbon-concentration.yml
@@ -534,8 +534,8 @@ var-requires36:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: CCl4
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_gas_concentration_below_calculated_detaction_limit_contact_data_originator_for_more_information. bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires37:
   func: checksit.generic.check_var
   params:
@@ -546,8 +546,8 @@ var-requires37:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: CHBr3
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_gas_concentration_below_calculated_detaction_limit_contact_data_originator_for_more_information. bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires38:
   func: checksit.generic.check_var
   params:
@@ -558,8 +558,8 @@ var-requires38:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: CH2I2
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_gas_concentration_below_calculated_detaction_limit_contact_data_originator_for_more_information. bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires39:
   func: checksit.generic.check_var
   params:
@@ -570,8 +570,8 @@ var-requires39:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: CH2ICl
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_gas_concentration_below_calculated_detaction_limit_contact_data_originator_for_more_information. bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires40:
   func: checksit.generic.check_var
   params:
@@ -582,8 +582,8 @@ var-requires40:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: CHBrCl2
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_gas_concentration_below_calculated_detaction_limit_contact_data_originator_for_more_information. bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires41:
   func: checksit.generic.check_var
   params:
@@ -594,8 +594,8 @@ var-requires41:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: CH2Br2
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_gas_concentration_below_calculated_detaction_limit_contact_data_originator_for_more_information. bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires42:
   func: checksit.generic.check_var
   params:
@@ -606,8 +606,8 @@ var-requires42:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: CHCl3
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_gas_concentration_below_calculated_detaction_limit_contact_data_originator_for_more_information. bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires43:
   func: checksit.generic.check_var
   params:
@@ -618,8 +618,8 @@ var-requires43:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: CH3I
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_gas_concentration_below_calculated_detaction_limit_contact_data_originator_for_more_information. bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires44:
   func: checksit.generic.check_var
   params:
@@ -630,5 +630,5 @@ var-requires44:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: CH2BrCl
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_gas_concentration_below_calculated_detaction_limit_contact_data_originator_for_more_information. bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-iwv-lwp.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-iwv-lwp.yml
@@ -38,8 +38,8 @@ var-requires2:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Temperature
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_temperature_outside_sensor_operational_range bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires3:
   func: checksit.generic.check_var
   params:
@@ -50,8 +50,8 @@ var-requires3:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_relative_humidity_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -62,8 +62,8 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Pressure
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_pressure_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -74,8 +74,8 @@ var-requires5:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Precipitation
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_precipitation_detected suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -86,8 +86,8 @@ var-requires6:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -98,8 +98,8 @@ var-requires7:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -110,8 +110,8 @@ var-requires8:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -122,8 +122,8 @@ var-requires9:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -134,8 +134,8 @@ var-requires10:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -146,8 +146,8 @@ var-requires11:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -158,8 +158,8 @@ var-requires12:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -170,8 +170,8 @@ var-requires13:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -182,8 +182,8 @@ var-requires14:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -194,8 +194,8 @@ var-requires15:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -206,8 +206,8 @@ var-requires16:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -218,8 +218,8 @@ var-requires17:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -230,8 +230,8 @@ var-requires18:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -242,8 +242,8 @@ var-requires19:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -254,8 +254,8 @@ var-requires20:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b
-      - flag_meanings:not_used good_data_temperature_stability_in_the_range_0_to_5mK suspect_data_temperature_stability_in_the_range_5_to_10mK suspect_data_temperature_stability_in_the_range_10_to_50mK suspect_data_temperature_stability_in_the_range_50_to_100mK suspect_data_temperature_stability_in_the_range_100_to_500mK bad_data_temperature_stability_>500mK suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -266,5 +266,5 @@ var-requires21:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b
-      - flag_meanings:not_used good_data_temperature_stability_in_the_range_0_to_5mK suspect_data_temperature_stability_in_the_range_5_to_10mK suspect_data_temperature_stability_in_the_range_10_to_50mK suspect_data_temperature_stability_in_the_range_50_to_100mK suspect_data_temperature_stability_in_the_range_100_to_500mK bad_data_temperature_stability_>500mK suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-liquid-water-content.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-liquid-water-content.yml
@@ -22,5 +22,5 @@ var-requires1:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b
-      - flag_meanings:not_used good_data bad_data_do not_use
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-mean-co2-h2o.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-mean-co2-h2o.yml
@@ -198,8 +198,8 @@ var-requires12:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Temperature
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(-25_C_to_50_C) suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -210,8 +210,8 @@ var-requires13:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Pressure
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(650_hPa_to_1150_hPa) suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -222,8 +222,8 @@ var-requires14:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Carbon Dioxide concentration
-      - flag_values:0b,1b, 2b, 3b,4b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(0_to_3_mmol_mol-1) suspect_data_measured_concentration_=_0 suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -234,5 +234,5 @@ var-requires15:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Water Vapor concentration
-      - flag_values:0b,1b, 2b, 3b,4b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(0_to_60_mmol_mol-1) suspect_data_measured_concentration_=_0 suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-mean-winds-profile.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-mean-winds-profile.yml
@@ -211,8 +211,8 @@ var-requires13:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b, 8b, 9b
-      - flag_meanings:not_used good_data bad_data_data_values_outside_measurement_range bad_data_signal_below_instrument _threshold suspect_data_line_of_sight_radial_velocity_ -19m_s-1_<> _19m_s-1 suspect_data_line_of_sight_radial_velocity_wind_shear_-5m_s-1_<>_5m_s-1 suspect_data_instrument_internal_temperature_outside_operational_range_low _(15C) suspect_data_Instrument_internal_temperature_outside_operational_range_high_(40C) bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-mean-winds.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-mean-winds.yml
@@ -225,8 +225,8 @@ var-requires14:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Sonic Temperature
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(-30C_to_50C) suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -237,8 +237,8 @@ var-requires15:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Wind Speed
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(0_to_50m_s-1) suspect_data_measured_wind_speed_==_0 suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -249,8 +249,8 @@ var-requires16:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Wind Direction
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(0_to_360_degrees) suspect_data_measured_wind_speed_==_0 suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -261,8 +261,8 @@ var-requires17:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Eastward Wind Component (U)
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(-50m_s-1_to_50m_s-1) suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -273,8 +273,8 @@ var-requires18:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Northward Wind Component (V)
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(-50m_s-1_to_50m_s-1) suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -285,5 +285,5 @@ var-requires19:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Upward Air Velocity Component (W)
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(-50m_s-1_to_50m_s-1) suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-moisture-profiles.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-moisture-profiles.yml
@@ -55,8 +55,8 @@ var-requires3:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Temperature
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_temperature_outside_sensor_operational_range bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -67,8 +67,8 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_relative_humidity_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -79,8 +79,8 @@ var-requires5:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Surface Pressure
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_pressure_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -91,8 +91,8 @@ var-requires6:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Precipitation
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_precipitation_detected suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -103,8 +103,8 @@ var-requires7:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -115,8 +115,8 @@ var-requires8:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -127,8 +127,8 @@ var-requires9:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -139,8 +139,8 @@ var-requires10:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -151,8 +151,8 @@ var-requires11:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -163,8 +163,8 @@ var-requires12:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -175,8 +175,8 @@ var-requires13:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -187,8 +187,8 @@ var-requires14:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -199,8 +199,8 @@ var-requires15:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -211,8 +211,8 @@ var-requires16:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -223,8 +223,8 @@ var-requires17:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -235,8 +235,8 @@ var-requires18:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -247,8 +247,8 @@ var-requires19:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -259,8 +259,8 @@ var-requires20:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failed
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_channel_failure suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -271,8 +271,8 @@ var-requires21:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b
-      - flag_meanings:not_used good_data_temperature_stability_in_the_range_0_to_5mK suspect_data_temperature_stability_in_the_range_5_to_10mK suspect_data_temperature_stability_in_the_range_10_to_50mK suspect_data_temperature_stability_in_the_range_50_to_100mK suspect_data_temperature_stability_in_the_range_100_to_500mK bad_data_temperature_stability_>500mK suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires22:
   func: checksit.generic.check_var
   params:
@@ -283,8 +283,8 @@ var-requires22:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b
-      - flag_meanings:not_used good_data_temperature_stability_in_the_range_0_to_5mK suspect_data_temperature_stability_in_the_range_5_to_10mK suspect_data_temperature_stability_in_the_range_10_to_50mK suspect_data_temperature_stability_in_the_range_50_to_100mK suspect_data_temperature_stability_in_the_range_100_to_500mK bad_data_temperature_stability_>500mK suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-n2o-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-n2o-concentration.yml
@@ -70,5 +70,5 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-n2o-sf6-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-n2o-sf6-concentration.yml
@@ -128,8 +128,8 @@ var-requires8:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: N2O
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -140,5 +140,5 @@ var-requires9:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: SF6
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-no2-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-no2-concentration.yml
@@ -70,5 +70,5 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b,3b
-      - flag_meanings:not_used good_data bad_data_gas_concentration_outside_instrument_operational _range suspect_data_time_stamp _error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-nox-noxy-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-nox-noxy-concentration.yml
@@ -248,8 +248,8 @@ var-requires16:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: NO
-      - flag_values:0b,1b, 2b
-      - flag_meanings:not_used good_data bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -260,8 +260,8 @@ var-requires17:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: NO2
-      - flag_values:0b,1b, 2b
-      - flag_meanings:not_used good_data bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -272,8 +272,8 @@ var-requires18:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: NOx
-      - flag_values:0b,1b, 2b
-      - flag_meanings:not_used good_data bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -284,5 +284,5 @@ var-requires19:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: NOy
-      - flag_values:0b,1b, 2b
-      - flag_meanings:not_used good_data bad_data_do_not_use
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-o2n2-concentration-ratio.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-o2n2-concentration-ratio.yml
@@ -22,5 +22,5 @@ var-requires1:
       - dimension:time
       - units:1
       - long_name:Data Quality Flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_gas_concentration_outside_instrument_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-o3-concentration-profile.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-o3-concentration-profile.yml
@@ -86,8 +86,8 @@ var-requires5:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_no ozone_wavelengths_available bad_data_gate_index_exceeds_number_of_measurement_gates_in_use
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-o3-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-o3-concentration.yml
@@ -70,5 +70,5 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-oh-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-oh-concentration.yml
@@ -64,5 +64,5 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_gas_concentration_outside_instrument_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-particle-size-distribution.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-particle-size-distribution.yml
@@ -145,8 +145,8 @@ var-requires10:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Temperature
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_bad_data_to_be_defined suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -157,8 +157,8 @@ var-requires11:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Pressure
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_bad_data_to_be_defined suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -169,8 +169,8 @@ var-requires12:
       - dimension:time, index
       - units:1
       - long_name:Data Quality flag: Instrument Counts
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_bad_data_to_be_defined suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -181,8 +181,8 @@ var-requires13:
       - dimension:time, index
       - units:1
       - long_name:Data Quality flag: Ambient Particle Number per Channel
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_bad_data_to_be_defined suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-peroxyacetyl-nitrate-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-peroxyacetyl-nitrate-concentration.yml
@@ -70,5 +70,5 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag:
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-pm-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-pm-concentration.yml
@@ -144,8 +144,8 @@ var-requires9:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: PM1
-      - flag_values:0b, 1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_pm1_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -156,8 +156,8 @@ var-requires10:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: PM2.5
-      - flag_values:0b, 1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_pm2.5_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -168,8 +168,8 @@ var-requires11:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: PM4
-      - flag_values:0b, 1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_pm4_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -180,8 +180,8 @@ var-requires12:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: PM10
-      - flag_values:0b, 1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_pm10_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -192,8 +192,8 @@ var-requires13:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Total PM
-      - flag_values:0b, 1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_total_pm_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -204,8 +204,8 @@ var-requires14:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Total Number
-      - flag_values:0b, 1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_total_number_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -216,8 +216,8 @@ var-requires15:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Temperature
-      - flag_values:0b,1b,2b,3b
-      - flag_meanings:not_used good_data bad_data_temperature_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -228,8 +228,8 @@ var-requires16:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Relative Humidity
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_relative_humidity_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -240,5 +240,5 @@ var-requires17:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Pressure
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_pressure_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-radiation.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-radiation.yml
@@ -85,8 +85,8 @@ var-requires5:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: upwelling shortwave
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_sw_radiation_<_0 bad_data_sw_radiation_>_2000_W_m-2 suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -97,8 +97,8 @@ var-requires6:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: downwelling shortwave
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_sw_radiation_<_0 bad_data_sw_radiation_>_2000_W_m-2 suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -109,8 +109,8 @@ var-requires7:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: upwelling longwave
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_lw_radiation_<_0 bad_data_lw_radiation_>_1000_W_m-2 suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -121,8 +121,8 @@ var-requires8:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: downwelling longwave
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_lw_radiation_<_0 bad_data_lw_radiation_>_1000_W_m-2 suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -133,8 +133,8 @@ var-requires9:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Body Temperature
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_body_temperature_outside_operational_range_(-40C_to_80C) suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -145,5 +145,5 @@ var-requires10:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: sensor cleaning
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_sensor_being_cleaned suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-rain-lwc-velocity-reflectivity.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-rain-lwc-velocity-reflectivity.yml
@@ -115,8 +115,8 @@ var-requires7:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b, 8b
-      - flag_meanings:not_used good_data suspect_data_zero_radar_return bad_data_rainfall_rate_<_0_mm_hr-1 suspect_data_rainfall_rate_>_300_mm_hr-1 bad_data_rainfall_velocity_<_0_m_s-1 good_data_rainfall_rate_=_0_m_s-1 bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-size-concentration-spectra.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-size-concentration-spectra.yml
@@ -69,8 +69,8 @@ var-requires4:
       - dimension:time, altitude, index_bin
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b, 4b, 5b, 6b, 7b, 8b
-      - flag_meanings:not_used good_data suspect_data_zero_radar_return bad_data_rainfall_rate_<_0_mm_hr-1 suspect_data_rainfall_rate_>_300_mm_hr-1 bad_data_rainfall_velocity_<_0_m_s-1 good_data_rainfall_rate_=_0_m_s-1 bad_data_gate_index_exceeds_number_of_measurement_gates_in_use suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-snr-winds.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-snr-winds.yml
@@ -281,8 +281,8 @@ var-requires18:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: Mean Winds
-      - flag_values:0b,1b,2b,3b
-      - flag_meanings:not_used good_data bad_data bad_data_gates_not_available
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -293,8 +293,8 @@ var-requires19:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: SNR Beam 1 (back panel)
-      - flag_values:0b,1b,2b,3b
-      - flag_meanings:not_used good_data bad_data bad_data_gates_not_available
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -305,8 +305,8 @@ var-requires20:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: SNR Beam 2 (side panel)
-      - flag_values:0b,1b,2b,3b
-      - flag_meanings:not_used good_data bad_data bad_data_gates_not_available
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -317,8 +317,8 @@ var-requires21:
       - dimension:time, altitude
       - units:1
       - long_name:Data Quality flag: SNR Beam 3 (vertical beam from centre panel)
-      - flag_values:0b,1b,2b,3b
-      - flag_meanings:not_used good_data bad_data bad_data_gates_not_available
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires22:
   func: checksit.generic.check_var
   params:
@@ -329,8 +329,8 @@ var-requires22:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Rain Detected
-      - flag_values:0b,1b,2b,3b
-      - flag_meanings:not_used good_data_no_rain suspect_data_rain_detected suspect_data_discontinuous_rain
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-so2-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-so2-concentration.yml
@@ -70,5 +70,5 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-soil.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-soil.yml
@@ -55,8 +55,8 @@ var-requires3:
       - dimension:time, index
       - units:1
       - long_name:Data Quality flag: Soil Heat Flux
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(-30C_to_70C) suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -67,8 +67,8 @@ var-requires4:
       - dimension:time, index
       - units:1
       - long_name:Data Quality flag: Soil Temperature
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_value_outside_operational_range_(-35C_to_50C) suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -79,8 +79,8 @@ var-requires5:
       - dimension:time, index
       - units:1
       - long_name:Data Quality flag: Soil Water Potential
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_soil_water_potential_>_80 kPa_contact_between_soil_and_sensor_usually_lost bad_data_value_outside_operational_range_(0_to_200_kPa) suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.0.0/amof-solar-actinic-flux.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-solar-actinic-flux.yml
@@ -78,5 +78,5 @@ var-requires5:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-sonde.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-sonde.yml
@@ -164,5 +164,5 @@ var-requires10:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b,2b,3b
-      - flag_meanings:not_used good_data suspect_data_no_measurable_ascent_rate suspect_data_horizontal_wind_speed_==_0_m_s-1
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-surface-met.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-surface-met.yml
@@ -212,8 +212,8 @@ var-requires13:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Temperature
-      - flag_values:0b,1b,2b,3b
-      - flag_meanings:not_used good_data bad_data_temperature_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -224,8 +224,8 @@ var-requires14:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Relative Humidity
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_relative_humidity_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -236,8 +236,8 @@ var-requires15:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Pressure
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data bad_data_pressure_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -248,8 +248,8 @@ var-requires16:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Wind Speed
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data suspect_data_measured_wind_speed_==_0_m_s-1 bad_data_wind_speed_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -260,8 +260,8 @@ var-requires17:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Wind From Direction
-      - flag_values:0b,1b, 2b, 3b, 4b,
-      - flag_meanings:not_used good_data suspect_data_measured_wind_speed_==_0_m_s-1 bad_data_wind_direction_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -272,8 +272,8 @@ var-requires18:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Radiation
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_longwave_radiation_outside_sensor_operational_range bad_data_shortwave_radiation_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -284,8 +284,8 @@ var-requires19:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: Precipitation
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_rainfall_rate_outside_sensor_operational_range bad_data_accumulated_rain_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -296,8 +296,8 @@ var-requires20:
       - dimension:time
       - units:1
       - long_name:Data Quality Flag: Downwelling Total Irradiance
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_longwave_radiation_outside_sensor_operational_range bad_data_shortwave_radiation_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -308,5 +308,5 @@ var-requires21:
       - dimension:time
       - units:1
       - long_name:Data Quality Flag: Net Total Irradiance
-      - flag_values:0b,1b, 2b, 3b, 4b
-      - flag_meanings:not_used good_data bad_data_longwave_radiation_outside_sensor_operational_range bad_data_shortwave_radiation_outside_sensor_operational_range suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-tgm-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-tgm-concentration.yml
@@ -70,5 +70,5 @@ var-requires4:
       - dimension:time
       - units:1
       - long_name:Data Quality flag
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.0.0/amof-voc-concentration.yml
+++ b/specs/groups/ncas-amof-2.0.0/amof-voc-concentration.yml
@@ -1034,8 +1034,8 @@ var-requires68:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: C2H6
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires69:
   func: checksit.generic.check_var
   params:
@@ -1046,8 +1046,8 @@ var-requires69:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: C2H4
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires70:
   func: checksit.generic.check_var
   params:
@@ -1058,8 +1058,8 @@ var-requires70:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: C3H8
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires71:
   func: checksit.generic.check_var
   params:
@@ -1070,8 +1070,8 @@ var-requires71:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: C3H6
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires72:
   func: checksit.generic.check_var
   params:
@@ -1082,8 +1082,8 @@ var-requires72:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: C4H10
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires73:
   func: checksit.generic.check_var
   params:
@@ -1094,8 +1094,8 @@ var-requires73:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: C2H2
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires74:
   func: checksit.generic.check_var
   params:
@@ -1106,8 +1106,8 @@ var-requires74:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: C5H12
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires75:
   func: checksit.generic.check_var
   params:
@@ -1118,8 +1118,8 @@ var-requires75:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: C5H8
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags
 var-requires76:
   func: checksit.generic.check_var
   params:
@@ -1130,5 +1130,5 @@ var-requires76:
       - dimension:time
       - units:1
       - long_name:Data Quality flag: C6H6
-      - flag_values:0b,1b, 2b, 3b
-      - flag_meanings:not_used good_data suspect_data_unspecified_instrument_performance_issues_contact_data_originator_for_more_information suspect_data_time_stamp_error
+    attr_rules:
+      - rule-func:check-qc-flags


### PR DESCRIPTION
Better checking of QC flag values and flag meanings
- Previously, checksit required QC flag_values and flag_meanings to match those given in the spreadsheets, but the standard states that QC flags aren't completely strictly tied down.
- There are a couple of exact requirements:
  - QC flags_values `0` and `1` must be used
  - They must associated flag_meanings `not_used` and `good_data`
  - The number of QC flag_values must be equal to the number of QC flag_meanings
A new rule function has been added that checks all of these, and the specs updated to use this rather than the previous checks.