### PR TITLE
Correcting ncas-amof-2.1.0 specs

### DIFF
--- a/checksit/vocabs/AMF_CVs/2.1.0/AMF_product.json
+++ b/checksit/vocabs/AMF_CVs/2.1.0/AMF_product.json
@@ -15,7 +15,7 @@
         "ch4-co2-h2o-co-concentration",
         "ch4-co2-h2o-concentration",
         "ch4-concentration",
-        "ch4-n2o-co-concentration",
+        "ch4-n2o-co2-co-concentration",
         "cloud-base",
         "cloud-coverage",
         "co-concentration",

--- a/specs/groups/ncas-amof-2.1.0/amof-acoustic-backscatter-winds.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-acoustic-backscatter-winds.yml
@@ -166,7 +166,7 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag: Mean Winds
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -178,7 +178,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag: Eastward Wind Component (U)
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -190,7 +190,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag: Northward Wind Component (V)
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -202,7 +202,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Upward Air Velocity (W)
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -214,7 +214,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Backscatter
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -226,7 +226,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Background Noise
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-aerosol-backscatter-radial-winds.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-aerosol-backscatter-radial-winds.yml
@@ -125,7 +125,7 @@ var-requires8:
       - units:1
       - long_name:Data Quality flag: Radial Velocity of Scatterers Away From Instrument
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -137,7 +137,7 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: Backscatter
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-aerosol-backscatter.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-aerosol-backscatter.yml
@@ -207,7 +207,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-aerosol-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-aerosol-concentration.yml
@@ -24,4 +24,4 @@ var-requires1:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-aerosol-extinction.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-aerosol-extinction.yml
@@ -53,7 +53,7 @@ var-requires3:
       - units:1
       - long_name:Data Quality flag: 355nm
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -65,7 +65,7 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag: 316nm
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-aerosol-no3-so4-nh3-org-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-aerosol-no3-so4-nh3-org-concentration.yml
@@ -69,7 +69,7 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag: NO3
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -81,7 +81,7 @@ var-requires5:
       - units:1
       - long_name:Data Quality flag: SO4
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -93,7 +93,7 @@ var-requires6:
       - units:1
       - long_name:Data Quality flag: NH3
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -105,4 +105,4 @@ var-requires7:
       - units:1
       - long_name:Data Quality flag: Organics
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-aerosol-optical-depth.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-aerosol-optical-depth.yml
@@ -53,7 +53,7 @@ var-requires3:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-aerosol-size-distribution.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-aerosol-size-distribution.yml
@@ -160,7 +160,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-boundary-layer-temperature-profiles.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-boundary-layer-temperature-profiles.yml
@@ -41,7 +41,7 @@ var-requires2:
       - units:1
       - long_name:Data Quality flag: Surface Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires3:
   func: checksit.generic.check_var
   params:
@@ -53,7 +53,7 @@ var-requires3:
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -65,7 +65,7 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag: Surface Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -77,7 +77,7 @@ var-requires5:
       - units:1
       - long_name:Data Quality flag: Precipitation
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -89,7 +89,7 @@ var-requires6:
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -101,7 +101,7 @@ var-requires7:
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -113,7 +113,7 @@ var-requires8:
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -125,7 +125,7 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -137,7 +137,7 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -149,7 +149,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -161,7 +161,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -173,7 +173,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -185,7 +185,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -197,7 +197,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -209,7 +209,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -221,7 +221,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -233,7 +233,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -245,7 +245,7 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -257,7 +257,7 @@ var-requires20:
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -269,7 +269,7 @@ var-requires21:
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-boundary-layer-thickness-ceilometer.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-boundary-layer-thickness-ceilometer.yml
@@ -177,7 +177,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-boundary-layer-thickness.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-boundary-layer-thickness.yml
@@ -25,7 +25,7 @@ var-requires1:
       - units:1
       - long_name:Data Quality flag: Surface Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires2:
   func: checksit.generic.check_var
   params:
@@ -37,7 +37,7 @@ var-requires2:
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires3:
   func: checksit.generic.check_var
   params:
@@ -49,7 +49,7 @@ var-requires3:
       - units:1
       - long_name:Data Quality flag: Surface Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -61,7 +61,7 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag: Precipitation
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -73,7 +73,7 @@ var-requires5:
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -85,7 +85,7 @@ var-requires6:
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -97,7 +97,7 @@ var-requires7:
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -109,7 +109,7 @@ var-requires8:
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -121,7 +121,7 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -133,7 +133,7 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -145,7 +145,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -157,7 +157,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -169,7 +169,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -181,7 +181,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -193,7 +193,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -205,7 +205,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -217,7 +217,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -229,7 +229,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -241,7 +241,7 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -253,4 +253,4 @@ var-requires20:
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-brightness-temperature.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-brightness-temperature.yml
@@ -55,7 +55,7 @@ var-requires3:
       - units:1
       - long_name:Data Quality flag: Surface Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -67,7 +67,7 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -79,7 +79,7 @@ var-requires5:
       - units:1
       - long_name:Data Quality flag: Surface Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -91,7 +91,7 @@ var-requires6:
       - units:1
       - long_name:Data Quality flag: Precipitation
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -103,7 +103,7 @@ var-requires7:
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -115,7 +115,7 @@ var-requires8:
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -127,7 +127,7 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -139,7 +139,7 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -151,7 +151,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -163,7 +163,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -175,7 +175,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -187,7 +187,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -199,7 +199,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -211,7 +211,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -223,7 +223,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -235,7 +235,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -247,7 +247,7 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -259,7 +259,7 @@ var-requires20:
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -271,7 +271,7 @@ var-requires21:
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires22:
   func: checksit.generic.check_var
   params:
@@ -283,7 +283,7 @@ var-requires22:
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-ch4-co2-h2o-co-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-ch4-co2-h2o-co-concentration.yml
@@ -256,7 +256,7 @@ var-requires16:
       - units:1.00E+00
       - long_name:Data Quality flag: CH4
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -268,7 +268,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: CO2
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -280,7 +280,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: H2O
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -292,4 +292,4 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: CO
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-ch4-co2-h2o-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-ch4-co2-h2o-concentration.yml
@@ -194,7 +194,7 @@ var-requires12:
       - units:1.00E+00
       - long_name:Data Quality flag: CH4
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -206,7 +206,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: CO2
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -218,4 +218,4 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: H2O
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-ch4-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-ch4-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-ch4-n2o-co2-co-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-ch4-n2o-co2-co-concentration.yml
@@ -257,7 +257,7 @@ var-requires16:
       - units:1.00E+00
       - long_name:Data Quality flag: CH4
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -269,7 +269,7 @@ var-requires17:
       - units:1.00E+00
       - long_name:Data Quality flag: N2O
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -281,7 +281,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: CO2
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -293,4 +293,4 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: CO
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-ch4-n2o-co2-co-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-ch4-n2o-co2-co-concentration.yml
@@ -1,0 +1,296 @@
+var-requires0:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mole_fraction_of_methane_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - standard_name:mole_fraction_of_methane_in_air
+      - long_name:Mole Fraction of Methane in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CH4
+var-requires1:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mass_fraction_of_methane_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - standard_name:mass_fraction_of_methane_in_air
+      - long_name:Mass Fraction of Methane in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CH4
+var-requires2:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mole_concentration_of_methane_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - units:mol m-3
+      - standard_name:mole_concentration_of_methane_in_air
+      - long_name:Mole Concentration of Methane in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CH4
+var-requires3:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mass_concentration_of_methane_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - units:kg m-3
+      - standard_name:mass_concentration_of_methane_in_air
+      - long_name:Mass Concentration of Methane in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CH4
+var-requires4:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mole_fraction_of_nitrous_oxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - standard_name:mole_fraction_of_nitrous_oxide_in_air
+      - long_name:Mole Fraction of Nitrous Oxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:N2O
+var-requires5:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mass_fraction_of_nitrous_oxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - standard_name:mass_fraction_of_nitrous_oxide_in_air
+      - long_name:Mass Fraction of Nitrous Oxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:N2O
+var-requires6:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mole_concentration_of_nitrous_oxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - units:mol m-3
+      - standard_name:mole_concentration_of_nitrous_oxide_in_air
+      - long_name:Mole Concentration of Nitrous Oxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:N2O
+var-requires7:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mass_concentration_of_nitrous_oxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - units:kg m-3
+      - standard_name:mass_concentration_of_nitrous_oxide_in_air
+      - long_name:Mass Concentration of Nitrous Oxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:N2O
+var-requires8:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mole_fraction_of_carbon_dioxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - standard_name:mole_fraction_of_carbon_dioxide_in_air
+      - long_name:Mole Fraction of Carbon Dioxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CO2
+var-requires9:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mass_fraction_of_carbon_dioxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - standard_name:mass_fraction_of_carbon_dioxide_in_air
+      - long_name:Mass Fraction of Carbon Dioxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CO2
+var-requires10:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mole_concentration_of_carbon_dioxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - units:mol m-3
+      - standard_name:mole_concentration_of_carbon_dioxide_in_air
+      - long_name:Mole Concentration of Carbon Dioxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CO2
+var-requires11:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mass_concentration_of_carbon_dioxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - units:kg m-3
+      - standard_name:mass_concentration_of_carbon_dioxide_in_air
+      - long_name:Mass Concentration of Carbon Dioxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CO2
+var-requires12:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mole_fraction_of_carbon_monoxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - standard_name:mole_fraction_of_carbon_monoxide_in_air
+      - long_name:Mole Fraction of Carbon Monoxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CO
+var-requires13:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mass_fraction_of_carbon_monoxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - standard_name:mass_fraction_of_carbon_monoxide_in_air
+      - long_name:Mass Fraction of Carbon Monoxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CO
+var-requires14:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mole_concentration_of_carbon_monoxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - units:mol m-3
+      - standard_name:mole_concentration_of_carbon_monoxide_in_air
+      - long_name:Mole Concentration of Carbon Monoxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CO
+var-requires15:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - mass_concentration_of_carbon_monoxide_in_air:__OPTIONAL__
+    defined_attrs:
+      - type:float
+      - dimension:time
+      - units:kg m-3
+      - standard_name:mass_concentration_of_carbon_monoxide_in_air
+      - long_name:Mass Concentration of Carbon Monoxide in air
+      - _FillValue:-1e+20
+      - valid_min:<derived from file>
+      - valid_max:<derived from file>
+      - coordinates:latitude longitude
+      - chemical_species:CO
+var-requires16:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - qc_flag_ch4:__OPTIONAL__
+    defined_attrs:
+      - type:byte
+      - dimension:time
+      - units:1.00E+00
+      - long_name:Data Quality flag: CH4
+    rules_attrs:
+      - rule-func:check-qc-flags
+var-requires17:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - qc_flag_n2o:__OPTIONAL__
+    defined_attrs:
+      - type:byte
+      - dimension:time
+      - units:1.00E+00
+      - long_name:Data Quality flag: N2O
+    rules_attrs:
+      - rule-func:check-qc-flags
+var-requires18:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - qc_flag_co2:__OPTIONAL__
+    defined_attrs:
+      - type:byte
+      - dimension:time
+      - units:1
+      - long_name:Data Quality flag: CO2
+    rules_attrs:
+      - rule-func:check-qc-flags
+var-requires19:
+  func: checksit.generic.check_var
+  params:
+    variable:
+      - qc_flag_co:__OPTIONAL__
+    defined_attrs:
+      - type:byte
+      - dimension:time
+      - units:1
+      - long_name:Data Quality flag: CO
+    rules_attrs:
+      - rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-cloud-base.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-cloud-base.yml
@@ -177,7 +177,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag: Cloud Base
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-cloud-coverage.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-cloud-coverage.yml
@@ -192,7 +192,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-co-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-co-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-co-h2-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-co-h2-concentration.yml
@@ -133,7 +133,7 @@ var-requires8:
       - units:1
       - long_name:Data Quality flag: CO
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -145,4 +145,4 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: H2
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-co2-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-co2-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-depolarisation-ratio.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-depolarisation-ratio.yml
@@ -154,7 +154,7 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag:  Attenuated backscatter coefficient (Planar Polarised)
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -166,7 +166,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag:  Attenuated backscatter coefficient (Cross Polarised)
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -178,7 +178,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag:  Depolarisation Ratio
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-dew-point.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-dew-point.yml
@@ -100,4 +100,4 @@ var-requires6:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-flux-components.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-flux-components.yml
@@ -1126,7 +1126,7 @@ var-requires74:
       - units:1
       - long_name:Quality flag: Skew U
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires75:
   func: checksit.generic.check_var
   params:
@@ -1138,7 +1138,7 @@ var-requires75:
       - units:1
       - long_name:Quality flag: Skew V
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires76:
   func: checksit.generic.check_var
   params:
@@ -1150,7 +1150,7 @@ var-requires76:
       - units:1
       - long_name:Quality flag: Skew W
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires77:
   func: checksit.generic.check_var
   params:
@@ -1162,7 +1162,7 @@ var-requires77:
       - units:1
       - long_name:Quality flag: Skew Ts
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires78:
   func: checksit.generic.check_var
   params:
@@ -1174,7 +1174,7 @@ var-requires78:
       - units:1
       - long_name:Quality flag: Kurtosis U
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires79:
   func: checksit.generic.check_var
   params:
@@ -1186,7 +1186,7 @@ var-requires79:
       - units:1
       - long_name:Quality flag: Kurtosis V
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires80:
   func: checksit.generic.check_var
   params:
@@ -1198,7 +1198,7 @@ var-requires80:
       - units:1
       - long_name:Quality flag: Kurtosis W
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires81:
   func: checksit.generic.check_var
   params:
@@ -1210,7 +1210,7 @@ var-requires81:
       - units:1
       - long_name:Quality flag: Kurtosis Ts
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires82:
   func: checksit.generic.check_var
   params:
@@ -1222,7 +1222,7 @@ var-requires82:
       - units:1
       - long_name:Quality flag: Steady State Class WU
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires83:
   func: checksit.generic.check_var
   params:
@@ -1234,7 +1234,7 @@ var-requires83:
       - units:1
       - long_name:Quality flag: Steady State Class WV
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires84:
   func: checksit.generic.check_var
   params:
@@ -1246,7 +1246,7 @@ var-requires84:
       - units:1
       - long_name:Quality flag: Steady State Class WTs
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires85:
   func: checksit.generic.check_var
   params:
@@ -1258,7 +1258,7 @@ var-requires85:
       - units:1
       - long_name:Quality flag: WU
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires86:
   func: checksit.generic.check_var
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-flux-estimates.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-flux-estimates.yml
@@ -173,7 +173,7 @@ var-requires11:
       - units:1
       - long_name:Quality flag: Skew U
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -185,7 +185,7 @@ var-requires12:
       - units:1
       - long_name:Quality flag: Skew V
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -197,7 +197,7 @@ var-requires13:
       - units:1
       - long_name:Quality flag: Skew W
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -209,7 +209,7 @@ var-requires14:
       - units:1
       - long_name:Quality flag: Skew Ts
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -221,7 +221,7 @@ var-requires15:
       - units:1
       - long_name:Quality flag: Kurtosis U
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -233,7 +233,7 @@ var-requires16:
       - units:1
       - long_name:Quality flag: Kurtosis V
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -245,7 +245,7 @@ var-requires17:
       - units:1
       - long_name:Quality flag: Kurtosis W
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -257,7 +257,7 @@ var-requires18:
       - units:1
       - long_name:Quality flag: Kurtosis Ts
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -269,7 +269,7 @@ var-requires19:
       - units:1
       - long_name:Quality flag: Steady State Class WU
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -281,7 +281,7 @@ var-requires20:
       - units:1
       - long_name:Quality flag: Steady State Class WV
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -293,7 +293,7 @@ var-requires21:
       - units:1
       - long_name:Quality flag: Steady State Class WTs
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires22:
   func: checksit.generic.check_var
   params:
@@ -305,7 +305,7 @@ var-requires22:
       - units:1
       - long_name:Quality flag: WU
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires23:
   func: checksit.generic.check_var
   params:
@@ -317,7 +317,7 @@ var-requires23:
       - units:1
       - long_name:Quality flag: WV
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires24:
   func: checksit.generic.check_var
   params:
@@ -329,7 +329,7 @@ var-requires24:
       - units:1
       - long_name:Quality flag: WTs
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires25:
   func: checksit.generic.check_var
   params:
@@ -341,4 +341,4 @@ var-requires25:
       - units:1
       - long_name:Quality flag: General Turbulent Characteristic of W Class
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-full-troposphere-temperature-profiles.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-full-troposphere-temperature-profiles.yml
@@ -41,7 +41,7 @@ var-requires2:
       - units:1
       - long_name:Data Quality flag: Surface Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires3:
   func: checksit.generic.check_var
   params:
@@ -53,7 +53,7 @@ var-requires3:
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -65,7 +65,7 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag: Surface Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -77,7 +77,7 @@ var-requires5:
       - units:1
       - long_name:Data Quality flag: Precipitation
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -89,7 +89,7 @@ var-requires6:
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -101,7 +101,7 @@ var-requires7:
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -113,7 +113,7 @@ var-requires8:
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -125,7 +125,7 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -137,7 +137,7 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -149,7 +149,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -161,7 +161,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -173,7 +173,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -185,7 +185,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -197,7 +197,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -209,7 +209,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -221,7 +221,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -233,7 +233,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -245,7 +245,7 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -257,7 +257,7 @@ var-requires20:
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -269,7 +269,7 @@ var-requires21:
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-h2-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-h2-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-halocarbon-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-halocarbon-concentration.yml
@@ -535,7 +535,7 @@ var-requires36:
       - units:1
       - long_name:Data Quality flag: CCl4
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires37:
   func: checksit.generic.check_var
   params:
@@ -547,7 +547,7 @@ var-requires37:
       - units:1
       - long_name:Data Quality flag: CHBr3
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires38:
   func: checksit.generic.check_var
   params:
@@ -559,7 +559,7 @@ var-requires38:
       - units:1
       - long_name:Data Quality flag: CH2I2
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires39:
   func: checksit.generic.check_var
   params:
@@ -571,7 +571,7 @@ var-requires39:
       - units:1
       - long_name:Data Quality flag: CH2ICl
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires40:
   func: checksit.generic.check_var
   params:
@@ -583,7 +583,7 @@ var-requires40:
       - units:1
       - long_name:Data Quality flag: CHBrCl2
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires41:
   func: checksit.generic.check_var
   params:
@@ -595,7 +595,7 @@ var-requires41:
       - units:1
       - long_name:Data Quality flag: CH2Br2
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires42:
   func: checksit.generic.check_var
   params:
@@ -607,7 +607,7 @@ var-requires42:
       - units:1
       - long_name:Data Quality flag: CHCl3
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires43:
   func: checksit.generic.check_var
   params:
@@ -619,7 +619,7 @@ var-requires43:
       - units:1
       - long_name:Data Quality flag: CH3I
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires44:
   func: checksit.generic.check_var
   params:
@@ -631,4 +631,4 @@ var-requires44:
       - units:1
       - long_name:Data Quality flag: CH2BrCl
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-iwv-lwp.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-iwv-lwp.yml
@@ -39,7 +39,7 @@ var-requires2:
       - units:1
       - long_name:Data Quality flag: Surface Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires3:
   func: checksit.generic.check_var
   params:
@@ -51,7 +51,7 @@ var-requires3:
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -63,7 +63,7 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag: Surface Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -75,7 +75,7 @@ var-requires5:
       - units:1
       - long_name:Data Quality flag: Precipitation
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -87,7 +87,7 @@ var-requires6:
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -99,7 +99,7 @@ var-requires7:
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -111,7 +111,7 @@ var-requires8:
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -123,7 +123,7 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -135,7 +135,7 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -147,7 +147,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -159,7 +159,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -171,7 +171,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -183,7 +183,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -195,7 +195,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -207,7 +207,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -219,7 +219,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -231,7 +231,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -243,7 +243,7 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -255,7 +255,7 @@ var-requires20:
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -267,4 +267,4 @@ var-requires21:
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-liquid-water-content.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-liquid-water-content.yml
@@ -23,4 +23,4 @@ var-requires1:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-mean-co2-h2o.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-mean-co2-h2o.yml
@@ -199,7 +199,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag: Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -211,7 +211,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -223,7 +223,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Carbon Dioxide concentration
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -235,4 +235,4 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Water Vapor concentration
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-mean-winds-profile.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-mean-winds-profile.yml
@@ -213,7 +213,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-mean-winds.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-mean-winds.yml
@@ -227,7 +227,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Sonic Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -239,7 +239,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Wind Speed
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -251,7 +251,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: Wind Direction
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -263,7 +263,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: Eastward Wind Component (U)
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -275,7 +275,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: Northward Wind Component (V)
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -287,4 +287,4 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: Upward Air Velocity Component (W)
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-moisture-profiles.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-moisture-profiles.yml
@@ -56,7 +56,7 @@ var-requires3:
       - units:1
       - long_name:Data Quality flag: Surface Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -68,7 +68,7 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -80,7 +80,7 @@ var-requires5:
       - units:1
       - long_name:Data Quality flag: Surface Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -92,7 +92,7 @@ var-requires6:
       - units:1
       - long_name:Data Quality flag: Precipitation
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -104,7 +104,7 @@ var-requires7:
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -116,7 +116,7 @@ var-requires8:
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -128,7 +128,7 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -140,7 +140,7 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -152,7 +152,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -164,7 +164,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -176,7 +176,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -188,7 +188,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -200,7 +200,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -212,7 +212,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -224,7 +224,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -236,7 +236,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -248,7 +248,7 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -260,7 +260,7 @@ var-requires20:
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -272,7 +272,7 @@ var-requires21:
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires22:
   func: checksit.generic.check_var
   params:
@@ -284,7 +284,7 @@ var-requires22:
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-n2o-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-n2o-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-n2o-sf6-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-n2o-sf6-concentration.yml
@@ -129,7 +129,7 @@ var-requires8:
       - units:1
       - long_name:Data Quality flag: N2O
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -141,4 +141,4 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: SF6
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-nh3-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-nh3-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-no2-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-no2-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-nox-noxy-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-nox-noxy-concentration.yml
@@ -249,7 +249,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: NO
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -261,7 +261,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: NO2
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -273,7 +273,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: NOx
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -285,4 +285,4 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: NOy
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-o2-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-o2-concentration.yml
@@ -67,4 +67,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-o2n2-concentration-ratio.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-o2n2-concentration-ratio.yml
@@ -23,4 +23,4 @@ var-requires1:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-o3-concentration-profile.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-o3-concentration-profile.yml
@@ -87,7 +87,7 @@ var-requires5:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-o3-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-o3-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-oh-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-oh-concentration.yml
@@ -65,4 +65,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-particle-size-distribution-cloud.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-particle-size-distribution-cloud.yml
@@ -208,7 +208,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -220,7 +220,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -232,7 +232,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: Instrument Counts
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -244,7 +244,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: Ambient Particle Number per Channel
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-particle-size-distribution.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-particle-size-distribution.yml
@@ -146,7 +146,7 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag: Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -158,7 +158,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag: Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -170,7 +170,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag: Instrument Counts
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -182,7 +182,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Ambient Particle Number per Channel
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-peroxyacetyl-nitrate-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-peroxyacetyl-nitrate-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-photolysis-frequencies.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-photolysis-frequencies.yml
@@ -65,4 +65,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-pm-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-pm-concentration.yml
@@ -145,7 +145,7 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: PM1
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -157,7 +157,7 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag: PM2.5
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -169,7 +169,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag: PM4
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -181,7 +181,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag: PM10
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -193,7 +193,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Total PM
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -205,7 +205,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Total Number
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -217,7 +217,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -229,7 +229,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: Relative Humidity
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -241,4 +241,4 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-precipitation.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-precipitation.yml
@@ -220,7 +220,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-present-weather.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-present-weather.yml
@@ -52,4 +52,4 @@ var-requires3:
       - units:1
       - long_name:Data quality flag for all variables
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-radiation.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-radiation.yml
@@ -88,7 +88,7 @@ var-requires5:
       - units:1
       - long_name:Data Quality flag: Upwelling shortwave
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires6:
   func: checksit.generic.check_var
   params:
@@ -100,7 +100,7 @@ var-requires6:
       - units:1
       - long_name:Data Quality flag: Downwelling shortwave
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -112,7 +112,7 @@ var-requires7:
       - units:1
       - long_name:Data Quality flag: Upwelling longwave
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -124,7 +124,7 @@ var-requires8:
       - units:1
       - long_name:Data Quality flag: Downwelling longwave
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -136,7 +136,7 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: Body Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -148,4 +148,4 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag: Sensor cleaning
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-radon-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-radon-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-radon-radioactivity.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-radon-radioactivity.yml
@@ -44,7 +44,7 @@ var-requires2:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 
 required-global-attrs:
   func: checksit.generic.check_global_attrs

--- a/specs/groups/ncas-amof-2.1.0/amof-rain-lwc-velocity-reflectivity.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-rain-lwc-velocity-reflectivity.yml
@@ -116,7 +116,7 @@ var-requires7:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-sf6-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-sf6-concentration.yml
@@ -67,4 +67,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-size-concentration-spectra.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-size-concentration-spectra.yml
@@ -70,7 +70,7 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-snr-winds.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-snr-winds.yml
@@ -282,7 +282,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: Mean Winds
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -294,7 +294,7 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: SNR Beam 1 (back panel)
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -306,7 +306,7 @@ var-requires20:
       - units:1
       - long_name:Data Quality flag: SNR Beam 2 (side panel)
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -318,7 +318,7 @@ var-requires21:
       - units:1
       - long_name:Data Quality flag: SNR Beam 3 (vertical beam from centre panel)
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires22:
   func: checksit.generic.check_var
   params:
@@ -330,7 +330,7 @@ var-requires22:
       - units:1
       - long_name:Data Quality flag: Rain Detected
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-so2-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-so2-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-soil.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-soil.yml
@@ -56,7 +56,7 @@ var-requires3:
       - units:1
       - long_name:Data Quality flag: Soil Heat Flux
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires4:
   func: checksit.generic.check_var
   params:
@@ -68,7 +68,7 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag: Soil Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires5:
   func: checksit.generic.check_var
   params:
@@ -80,7 +80,7 @@ var-requires5:
       - units:1
       - long_name:Data Quality flag: Soil Water Potential
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 dims-requires:
   func: checksit.generic.check_dim_exists
   params:

--- a/specs/groups/ncas-amof-2.1.0/amof-solar-actinic-flux.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-solar-actinic-flux.yml
@@ -79,4 +79,4 @@ var-requires5:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-sonde.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-sonde.yml
@@ -165,4 +165,4 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-stability-indices.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-stability-indices.yml
@@ -103,7 +103,7 @@ var-requires6:
       - units:1
       - long_name:Data Quality flag: Surface Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires7:
   func: checksit.generic.check_var
   params:
@@ -115,7 +115,7 @@ var-requires7:
       - units:1
       - long_name:Data Quality flag: Surface Relative Humidity
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires8:
   func: checksit.generic.check_var
   params:
@@ -127,7 +127,7 @@ var-requires8:
       - units:1
       - long_name:Data Quality flag: Surface Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires9:
   func: checksit.generic.check_var
   params:
@@ -139,7 +139,7 @@ var-requires9:
       - units:1
       - long_name:Data Quality flag: Precipitation
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires10:
   func: checksit.generic.check_var
   params:
@@ -151,7 +151,7 @@ var-requires10:
       - units:1
       - long_name:Data Quality flag: Receiver channel 1 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires11:
   func: checksit.generic.check_var
   params:
@@ -163,7 +163,7 @@ var-requires11:
       - units:1
       - long_name:Data Quality flag: Receiver channel 2 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires12:
   func: checksit.generic.check_var
   params:
@@ -175,7 +175,7 @@ var-requires12:
       - units:1
       - long_name:Data Quality flag: Receiver channel 3 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires13:
   func: checksit.generic.check_var
   params:
@@ -187,7 +187,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Receiver channel 4 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -199,7 +199,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Receiver channel 5 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -211,7 +211,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Receiver channel 6 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -223,7 +223,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: Receiver channel 7 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -235,7 +235,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: Receiver channel 8 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -247,7 +247,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: Receiver channel 9 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -259,7 +259,7 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: Receiver channel 10 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -271,7 +271,7 @@ var-requires20:
       - units:1
       - long_name:Data Quality flag: Receiver channel 11 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -283,7 +283,7 @@ var-requires21:
       - units:1
       - long_name:Data Quality flag: Receiver channel 12 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires22:
   func: checksit.generic.check_var
   params:
@@ -295,7 +295,7 @@ var-requires22:
       - units:1
       - long_name:Data Quality flag: Receiver channel 13 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires23:
   func: checksit.generic.check_var
   params:
@@ -307,7 +307,7 @@ var-requires23:
       - units:1
       - long_name:Data Quality flag: Receiver channel 14 failure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires24:
   func: checksit.generic.check_var
   params:
@@ -319,7 +319,7 @@ var-requires24:
       - units:1
       - long_name:Data Quality flag: Thermal stability of temperature receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires25:
   func: checksit.generic.check_var
   params:
@@ -331,4 +331,4 @@ var-requires25:
       - units:1
       - long_name:Data Quality flag: Thermal stability of moisture receiver bank
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-surface-met.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-surface-met.yml
@@ -213,7 +213,7 @@ var-requires13:
       - units:1
       - long_name:Data Quality flag: Temperature
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires14:
   func: checksit.generic.check_var
   params:
@@ -225,7 +225,7 @@ var-requires14:
       - units:1
       - long_name:Data Quality flag: Relative Humidity
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires15:
   func: checksit.generic.check_var
   params:
@@ -237,7 +237,7 @@ var-requires15:
       - units:1
       - long_name:Data Quality flag: Pressure
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires16:
   func: checksit.generic.check_var
   params:
@@ -249,7 +249,7 @@ var-requires16:
       - units:1
       - long_name:Data Quality flag: Wind Speed
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires17:
   func: checksit.generic.check_var
   params:
@@ -261,7 +261,7 @@ var-requires17:
       - units:1
       - long_name:Data Quality flag: Wind From Direction
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires18:
   func: checksit.generic.check_var
   params:
@@ -273,7 +273,7 @@ var-requires18:
       - units:1
       - long_name:Data Quality flag: Radiation
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires19:
   func: checksit.generic.check_var
   params:
@@ -285,7 +285,7 @@ var-requires19:
       - units:1
       - long_name:Data Quality flag: Precipitation
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires20:
   func: checksit.generic.check_var
   params:
@@ -297,7 +297,7 @@ var-requires20:
       - units:1
       - long_name:Data Quality flag: Downwelling Total Irradiance
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires21:
   func: checksit.generic.check_var
   params:
@@ -309,4 +309,4 @@ var-requires21:
       - units:1
       - long_name:Data Quality flag: Net Total Irradiance
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-tgm-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-tgm-concentration.yml
@@ -71,4 +71,4 @@ var-requires4:
       - units:1
       - long_name:Data Quality flag
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags

--- a/specs/groups/ncas-amof-2.1.0/amof-voc-concentration.yml
+++ b/specs/groups/ncas-amof-2.1.0/amof-voc-concentration.yml
@@ -1035,7 +1035,7 @@ var-requires68:
       - units:1
       - long_name:Data Quality flag: C2H6
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires69:
   func: checksit.generic.check_var
   params:
@@ -1047,7 +1047,7 @@ var-requires69:
       - units:1
       - long_name:Data Quality flag: C2H4
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires70:
   func: checksit.generic.check_var
   params:
@@ -1059,7 +1059,7 @@ var-requires70:
       - units:1
       - long_name:Data Quality flag: C3H8
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires71:
   func: checksit.generic.check_var
   params:
@@ -1071,7 +1071,7 @@ var-requires71:
       - units:1
       - long_name:Data Quality flag: C3H6
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires72:
   func: checksit.generic.check_var
   params:
@@ -1083,7 +1083,7 @@ var-requires72:
       - units:1
       - long_name:Data Quality flag: C4H10
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires73:
   func: checksit.generic.check_var
   params:
@@ -1095,7 +1095,7 @@ var-requires73:
       - units:1
       - long_name:Data Quality flag: C2H2
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires74:
   func: checksit.generic.check_var
   params:
@@ -1107,7 +1107,7 @@ var-requires74:
       - units:1
       - long_name:Data Quality flag: C5H12
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires75:
   func: checksit.generic.check_var
   params:
@@ -1119,7 +1119,7 @@ var-requires75:
       - units:1
       - long_name:Data Quality flag: C5H8
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags
 var-requires76:
   func: checksit.generic.check_var
   params:
@@ -1131,4 +1131,4 @@ var-requires76:
       - units:1
       - long_name:Data Quality flag: C6H6
     rules_attrs:
-      - rule-func:check-qc-flags
+      - flag_values: rule-func:check-qc-flags


### PR DESCRIPTION
Corrected the ch4-n2o-co2-co-concentration data product name from ch4-n2o-co-concentration, and corrected the rule func checks in the specs for qc flags.