### PR TITLE
Add check-files command

### DIFF
--- a/checksit/cli.py
+++ b/checksit/cli.py
@@ -7,7 +7,7 @@ __license__ = "BSD - see LICENSE file in top-level package directory"
 
 import click
 import os
-from typing import Optional, List
+from typing import Optional, List, Tuple
 
 from .utils import string_to_dict, string_to_list
 from .check import check_file
@@ -20,6 +20,112 @@ from . import specs
 def main():
     """Console script for checker."""
     return 0
+
+
+@main.command()
+@click.argument("file_paths", nargs=-1)
+@click.option("-m", "--mappings", default=None)
+@click.option("-r", "--rules", default=None)
+@click.option("-s", "--specs", default=None)
+@click.option("-i", "--ignore-attrs", default=None)
+@click.option("-G", "--ignore-all-globals", default=False)
+@click.option("-D", "--ignore-all-dimensions", default=False)
+@click.option("-V", "--ignore-all-variables", default=False)
+@click.option("-A", "--ignore-all-variable-attrs", default=False)
+@click.option("--auto-cache/--no-auto-cache", default=False)
+@click.option("-l", "--log-mode", default="standard")
+@click.option("-v", "--verbose/--no-verbose", default=False)
+@click.option("-t", "--template", default="auto")
+@click.option("-w", "--ignore-warnings", is_flag=True)
+@click.option("-p", "--skip-spellcheck", is_flag=True)
+def check_files(
+    file_paths: Tuple[str,...],
+    mappings: Optional[str] = None,
+    rules: Optional[str] = None,
+    specs: Optional[str] = None,
+    ignore_attrs: Optional[str] = None,
+    ignore_all_globals: bool = False,
+    ignore_all_dimensions: bool = False,
+    ignore_all_variables: bool = False,
+    ignore_all_variable_attrs: bool = False,
+    auto_cache: bool = False,
+    log_mode: str = "standard",
+    verbose: bool = False,
+    template: str = "auto",
+    ignore_warnings: bool = False,
+    skip_spellcheck: bool = False,
+):
+    """CLI call to check a number of files against a set of rules, specs or templates.
+
+    Reads options from the command line and calls the check_file function to check the
+    compliance of each file against a set of rules, specs or templates. If any of
+    `mappings`, `rules`, `specs` or `ignore_attrs` are provided as a string, they will
+    be converted to the appropriate data type.
+
+    Args:
+        file_paths: Paths to the files to check.
+        mappings: Map variable names between name used in file and name in template.
+          Format should be `<template variable name>=<file variable name>`. Multiple
+          mappings should be separated by a comma.
+        rules: Specific rules to use to check items. Format should be
+          `<what to check>=<rule type>:<function/check>[:<extras>[:<extras>...]]`.
+          Multiple rules should be separated by a comma.
+        specs: Specific specs to use to check items. Format should be `<spec file>` or
+          `<spec folder>/<spec file>`. File location and path relative to the specs
+          folder in the checksit repository. Multiple specs should be separated by a
+          comma.
+        ignore_attrs: Attributes to ignore when checking variables. Multiple attributes
+          should be separated by a comma.
+        ignore_all_globals: Not implemented yet.
+        ignore_all_dimensions: Not implemented yet.
+        ignore_all_variables: Not implemented yet.
+        ignore_all_variable_attrs: Not implemented yet.
+        auto_cache: Store the file in the template cache for future use as a template.
+        log_mode: How the output should be printed. Options are "standard" (default)
+          and "compact".
+        verbose: Print additional information to the console.
+        template: Template to use for checking. Options are "auto" (default), "off", or
+          `<template file>`. File location is relative to the top level of the checksit
+          repository.
+        ignore_warnings: Ignore warnings when checking the file, only return errors.
+        skip_spellcheck: Skip the spellcheck in rules and functions that utilise spell
+          checking.
+    """
+
+    if (
+        ignore_all_globals
+        or ignore_all_dimensions
+        or ignore_all_variables
+        or ignore_all_variable_attrs
+    ):
+        raise Exception("Options not implemented yet!!!!!")
+
+    if mappings is not None:
+        mappings = string_to_dict(mappings)
+
+    if rules is not None:
+        rules = string_to_dict(rules)
+
+    if specs is not None:
+        specs = string_to_list(specs)
+
+    if ignore_attrs is not None:
+        ignore_attrs = string_to_list(ignore_attrs)
+
+    for file_path in file_paths:
+        check_file(
+            file_path,
+            template=template,
+            mappings=mappings,
+            extra_rules=rules,
+            specs=specs,
+            ignore_attrs=ignore_attrs,
+            auto_cache=auto_cache,
+            verbose=verbose,
+            log_mode=log_mode,
+            ignore_warnings=ignore_warnings,
+            skip_spellcheck=skip_spellcheck,
+        )
 
 
 @main.command()

--- a/checksit/cli.py
+++ b/checksit/cli.py
@@ -112,7 +112,7 @@ def check(
     if ignore_attrs is not None:
         ignore_attrs = string_to_list(ignore_attrs)
 
-    return check_file(
+    check_file(
         file_path,
         template=template,
         mappings=mappings,
@@ -178,7 +178,7 @@ def summary(
                 ]
             )
 
-    return summarise(
+    summarise(
         log_files,
         log_directory=log_directory,
         show_files=show_files,
@@ -201,7 +201,7 @@ def describe(check_ids: Optional[List[str]] = None, verbose: bool = False):
         check_ids: List of rules to describe.
         verbose: Print additional information to the console.
     """
-    return describer.describe(check_ids, verbose=verbose)
+    describer.describe(check_ids, verbose=verbose)
 
 
 @main.command()
@@ -216,7 +216,7 @@ def show_specs(spec_ids: Optional[List[str]] = None):
     Args:
         spec_ids: List of specs to show.
     """
-    return specs.show_specs(spec_ids)
+    specs.show_specs(spec_ids)
 
 
 if __name__ == "__main__":

--- a/checksit/specs.py
+++ b/checksit/specs.py
@@ -9,6 +9,7 @@ import glob
 import json
 import yaml
 import importlib
+import sys
 from typing import List, Dict, Any, Union, Optional, Tuple
 from .config import get_config
 
@@ -155,7 +156,10 @@ class SpecificationChecker:
         parts = d["func"].split(".")
 
         mod_path, func = ".".join(parts[:-1]), parts[-1]
-        func = getattr(importlib.import_module(mod_path), func)
+        # Import the module if not already imported
+        if mod_path not in sys.modules:
+            importlib.import_module(mod_path)
+        func = getattr(sys.modules[mod_path], func)
 
         params = d["params"]
         params["skip_spellcheck"] = skip_spellcheck

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -18,10 +18,20 @@ Then ``checksit`` can be run using the following, as an example:
 
 .. code-block::
 
-   checksit check /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20671201-20681130.nc 
+   checksit check /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20671201-20681130.nc
 
 ``checksit`` will then look at the file given and attempt to find either a template file to
 compare against or a series of specs to match with, and then print out the results of the checks.
+
+Multiple Files
+--------------
+If you want to check multiple files, you can do so by using the ``check-files`` command and list
+all the files to check, for example:
+
+.. code-block::
+
+   checksit check-files /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20671201-20681130.nc /badc/ukcp18/data/land-cpm/uk/2.2km/rcp85/01/rss/day/latest/rss_rcp85_land-cpm_uk_2.2km_01_day_20681201-20691130.nc
+
 
 Specify Template
 ----------------


### PR DESCRIPTION
Checking NCAS files requires a call to GitHub for the latest instrument data. When checking a lot of files at once, this created a lot of calls to GitHub at once, a lot of which GitHub would reject, resulting in checksit errors. This PR address this by reducing the number of requests to GitHub needed when checking lots of files:
* within the SpecificationChecker class, the module that contains the function needed by the spec was imported every time, even if it has previously been imported. This meant that modules that themselves import the `cvs` module with the vocab checks (e.g. `checksit.generic`) were refreshing their vocab cache for each spec check. This has been changed to only import modules if not previously imported, allowing the vocab cache to persist across multiple spec checks.
* a new CLI command `check-files` has been added. This is functionally identical to the `check` CLI command, except that it takes a number of files as an argument and runs checksit on each. Doing this, rather than running `check` on each file sequentially, allows the vocab cache to persist from one file to the next.
* in case this still results in requests being denied, an additional function has been added to the loading of URLs, which sleeps for a few seconds and then tries again if either a 429 status code or a TimeoutError is returned 