### PR TITLE
Add ".0" to the end of X.Y version number for NCAS General

### DIFF
--- a/checksit/check.py
+++ b/checksit/check.py
@@ -371,6 +371,8 @@ class Checker:
                     .split("-")[2]
                     .replace('"', "")
                 )
+                if version_number.count(".") == 1:
+                    version_number = f"{version_number}.0"
                 spec_folder = f"ncas-amof-{version_number}"
                 if verbose:
                     print(f"  {version_number}")


### PR DESCRIPTION
If a file stated in the Conventions global attribute that it met version 2.0 (for example) of the NCAS-General standard, this would cause an issue in finding the correct specs to use as there is no 2.0, only 2.0.0. This change adds the extra ".0" in, in the same manner as is done for NCAS-Radar, to find the correct specs. Note: this doesn't change the value within the file, so the check of the Conventions global attribute will correctly fail.