### PR TITLE
Limit cf python for py3.10 and lower

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "click",
     "pyyaml",
     "cf-python < 3.19.0 ; python_version <= '3.10'",
+    "cf-python ; python_version >= '3.11'",
     "netcdf4",
     "pandas",
     "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 dependencies = [
     "click",
     "pyyaml",
-    "cf-python != 3.19.0",
+    "cf-python < 3.19.0 ; python_version <= '3.10'",
     "netcdf4",
     "pandas",
     "requests",


### PR DESCRIPTION
Newer versions of `cf` aren't installing on python 3.10 and lower due to a syntax change.